### PR TITLE
fixes to Llama 2 READMEs and models

### DIFF
--- a/llama-2-13b-chat/README.md
+++ b/llama-2-13b-chat/README.md
@@ -1,67 +1,81 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/llama)
+# Llama-2-chat 13B Truss
 
-# Llama-2 13B Chat Truss
-
-This is a [Truss](https://truss.baseten.co/) for Llama-2 13B Chat. Llama-2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama-2 13B Chat.
+This is a [Truss](https://truss.baseten.co/) for Llama-2-chat 13B. Llama 2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama-2-chat 13B.
 
 ## Truss
 
 Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
-## Deploying LLaMA2-13B Chat
+## Setup
 
-To deploy the Llama-2 13B Chat Truss, you'll need to follow these steps:
+[Sign up](https://app.baseten.co/signup) or [sign in](https://app.baseten.co/login/) to your Baseten account and create an [API key](https://app.baseten.co/settings/account/api_keys).
 
-1. __Prerequisites__: Make sure you have a Baseten account and API key. You can sign up for a Baseten account [here](https://app.baseten.co/signup).
+Then run:
 
-2. __Install Truss and the Baseten Python client__: If you haven't already, install the Baseten Python client and Truss in your development environment using:
 ```
-pip install --upgrade baseten truss
+pip install --upgrade baseten
+baseten login
 ```
 
-3. __Set HF API key__: To download the model, you'll need to pass your HF API key and be approved to download weights. Visit this [link](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) to begin the approval process. Once approved, update the `config.yaml` with your Huggingface API key (look for the key, `hf_api_key` in the config.yaml.)
+Paste your API key when prompted.
 
-4. __Load the LLaMA2-13B Chat Truss__: Assuming you've cloned this repo, spin up an IPython shell and load the Truss into memory:
-```
+### Get LLaMA-2 access
+
+LLaMA-2 currently requires approval to access. To request access:
+
+1. Go to [https://ai.meta.com/resources/models-and-libraries/llama-downloads/](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and request access using the email associated with your HuggingFace account.
+2. Go to [https://huggingface.co/meta-llama/Llama-2-13B](https://huggingface.co/meta-llama/Llama-2-13B) and request access.
+
+Once you have LLaMA access:
+
+1. Create a [HuggingFace access token](https://huggingface.co/settings/tokens)
+2. Set it as a [secret in your Baseten account](https://app.baseten.co/settings/secrets) with the name `hf_access_token`
+
+## Deployment
+
+In an iPython notebook, run the following script to deploy Llama-2-chat 13B to your Baseten account:
+
+```python
+import baseten
 import truss
 
-llama_2_13b_truss = truss.load("path/to/llama_2_13b_truss")
+llama = truss.load("truss-examples/llama-2-13b-chat/")
+baseten.deploy(
+  llama,
+  model_name="Llama-2-chat 13B",
+  is_trusted=True
+)
 ```
 
-5. __Log in to Baseten__: Log in to your Baseten account using your API key (key found [here](https://app.baseten.co/settings/account/api_keys)):
-```
-import baseten
+Once your Truss is deployed, you can start using the Llama-2-chat 13B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
 
-baseten.login("PASTE_API_KEY_HERE")
-```
+### Hardware notes
 
-6. __Deploy the LLaMA2-13B Chat Truss__: Deploy the LLaMA2-13B Chat Truss to Baseten with the following command:
-```
-baseten.deploy(llama_2_13b_truss)
-```
+This thirteen billion parameter model requires an A100 GPU.
 
-Once your Truss is deployed, you can start using the LLaMA2-13B Chat model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
+## Llama-2-chat 13B API documentation
 
-## LLaMA2-13B Chat API documentation
-This section provides an overview of the LLaMA2-13B Chat API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+This section provides an overview of the Llama-2-chat 13B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided prompt.
 
 ### API route: `predict`
-The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __instruction__: The input text that you want the model to generate a response for.
+The predict route is the primary method for generating text completions based on a given prompt. It takes several parameters:
+
+- __prompt__: The input text that you want the model to generate a response for.
 - __temperature__ (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
 - __top_p__ (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
 - __top_k__ (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
 - __num_beams__ (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
 
-The API also supports passing any parameter supported by Huggingface's `Transformers.generate`.
+The API also supports passing any parameter supported by HuggingFace's `Transformers.generate`.
 
 ## Example usage
 
 You can use the `baseten` model package to invoke your model from Python
-```
+
+```python
 import baseten
-# You can retrieve your deployed model ID from the UI
+# You can retrieve your deployed model version ID from the Baseten UI
 model = baseten.deployed_model_version_id('YOUR_MODEL_ID')
 
 request = {
@@ -75,9 +89,10 @@ request = {
 response = model.predict(request)
 ```
 
-You can also invoke your model via a REST API
+You can also invoke your model via a REST API:
+
 ```
-curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
+curl -X POST " https://app.baseten.co/model_versions/YOUR_MODEL_VERSION_ID/predict" \
      -H "Content-Type: application/json" \
      -H 'Authorization: Api-Key {YOUR_API_KEY}' \
      -d '{
@@ -87,5 +102,4 @@ curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
            "top_k": 40,
            "num_beams": 4
          }'
-
 ```

--- a/llama-2-13b-chat/config.yaml
+++ b/llama-2-13b-chat/config.yaml
@@ -38,6 +38,6 @@ resources:
   use_gpu: true
   accelerator: A100
 secrets:
-  hf_api_key: "ENTER HF API KEY HERE"
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 spec_version: '2.0'
 system_packages: []

--- a/llama-2-13b-chat/examples.yaml
+++ b/llama-2-13b-chat/examples.yaml
@@ -1,4 +1,0 @@
-- input:
-    inputs:
-    - - 0
-  name: example1

--- a/llama-2-13b-chat/model/model.py
+++ b/llama-2-13b-chat/model/model.py
@@ -23,12 +23,12 @@ class Model:
     def load(self):
         self._model = LlamaForCausalLM.from_pretrained(
             "meta-llama/Llama-2-13b-chat-hf", 
-            use_auth_token=self._secrets["hf_api_key"], 
+            use_auth_token=self._secrets["hf_access_token"], 
             device_map="auto"
         )
         self._tokenizer = LlamaTokenizer.from_pretrained(
             "meta-llama/Llama-2-13b-chat-hf", 
-            use_auth_token=self._secrets["hf_api_key"]
+            use_auth_token=self._secrets["hf_access_token"]
         )
 
     def preprocess(self, request: Dict) -> Dict:

--- a/llama-2-13b-truss/README.md
+++ b/llama-2-13b-truss/README.md
@@ -1,67 +1,81 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/llama)
+# Llama 2 13B Truss
 
-# LLaMA-2 13B Truss
-
-This is a [Truss](https://truss.baseten.co/) for LLaMA-2 13B Llama-2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of LLaMA-2 13B Chat.
+This is a [Truss](https://truss.baseten.co/) for Llama 2 13B. Llama 2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama 2 13B.
 
 ## Truss
 
-Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
+Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp)). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
-## Deploying LLaMA2-13B
+## Setup
 
-To deploy the LLaMA-2 13B Truss, you'll need to follow these steps:
+[Sign up](https://app.baseten.co/signup) or [sign in](https://app.baseten.co/login/) to your Baseten account and create an [API key](https://app.baseten.co/settings/account/api_keys).
 
-1. __Prerequisites__: Make sure you have a Baseten account and API key. You can sign up for a Baseten account [here](https://app.baseten.co/signup).
+Then run:
 
-2. __Install Truss and the Baseten Python client__: If you haven't already, install the Baseten Python client and Truss in your development environment using:
 ```
-pip install --upgrade baseten truss
+pip install --upgrade baseten
+baseten login
 ```
 
-3. __Set HF API key__: To download the model, you'll need to pass your HF API key and be approved to download weights. Visit this [link](https://huggingface.co/meta-llama/Llama-2-13B-hf) to begin the approval process. Once approved, update the `config.yaml` with your Huggingface API key (look for the key, `hf_api_key` in the config.yaml.)
+Paste your API key when prompted.
 
-4. __Load the LLaMA2-13B Truss__: Assuming you've cloned this repo, spin up an IPython shell and load the Truss into memory:
-```
+### Get Llama 2 access
+
+Llama 2 currently requires approval to access. To request access:
+
+1. Go to [https://ai.meta.com/resources/models-and-libraries/llama-downloads/](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and request access using the email associated with your HuggingFace account.
+2. Go to [https://huggingface.co/meta-llama/Llama-2-13B](https://huggingface.co/meta-llama/Llama-2-13B) and request access.
+
+Once you have Llama access:
+
+1. Create a [HuggingFace access token](https://huggingface.co/settings/tokens)
+2. Set it as a [secret in your Baseten account](https://app.baseten.co/settings/secrets) with the name `hf_access_token`
+
+## Deployment
+
+In an iPython notebook, run the following script to deploy Llama 2 13B to your Baseten account:
+
+```python
+import baseten
 import truss
 
-llama_13B_truss = truss.load("path/to/llama_13B_truss")
+llama = truss.load("truss-examples/llama-2-13b-truss/")
+baseten.deploy(
+  llama,
+  model_name="Llama 2 13B",
+  is_trusted=True
+)
 ```
 
-5. __Log in to Baseten__: Log in to your Baseten account using your API key (key found [here](https://app.baseten.co/settings/account/api_keys)):
-```
-import baseten
+Once your Truss is deployed, you can start using the Llama 2 13B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
 
-baseten.login("PASTE_API_KEY_HERE")
-```
+### Hardware notes
 
-6. __Deploy the LLaMA2-13B Truss__: Deploy the LLaMA2-13B Truss to Baseten with the following command:
-```
-baseten.deploy(llama_13B_truss)
-```
+This thirteen billion parameter model requires an A100 GPU.
 
-Once your Truss is deployed, you can start using the LLaMA2-13B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
+## Llama 2 13B API documentation
 
-## LLaMA2-13B API documentation
-This section provides an overview of the LLaMA2-13B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+This section provides an overview of the Llama 2 13B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided prompt.
 
 ### API route: `predict`
-The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __instruction__: The input text that you want the model to generate a response for.
+The predict route is the primary method for generating text completions based on a given prompt. It takes several parameters:
+
+- __prompt__: The input text that you want the model to generate a response for.
 - __temperature__ (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
 - __top_p__ (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
 - __top_k__ (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
 - __num_beams__ (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
 
-The API also supports passing any parameter supported by Huggingface's `Transformers.generate`.
+The API also supports passing any parameter supported by HuggingFace's `Transformers.generate`.
 
 ## Example usage
 
 You can use the `baseten` model package to invoke your model from Python
-```
+
+```python
 import baseten
-# You can retrieve your deployed model ID from the UI
+# You can retrieve your deployed model version ID from the Baseten UI
 model = baseten.deployed_model_version_id('YOUR_MODEL_ID')
 
 request = {
@@ -75,9 +89,10 @@ request = {
 response = model.predict(request)
 ```
 
-You can also invoke your model via a REST API
+You can also invoke your model via a REST API:
+
 ```
-curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
+curl -X POST " https://app.baseten.co/model_versions/YOUR_MODEL_VERSION_ID/predict" \
      -H "Content-Type: application/json" \
      -H 'Authorization: Api-Key {YOUR_API_KEY}' \
      -d '{
@@ -87,5 +102,4 @@ curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
            "top_k": 40,
            "num_beams": 4
          }'
-
 ```

--- a/llama-2-13b-truss/examples.yaml
+++ b/llama-2-13b-truss/examples.yaml
@@ -1,4 +1,0 @@
-- input:
-    inputs:
-    - - 0
-  name: example1

--- a/llama-2-70b-chat/README.md
+++ b/llama-2-70b-chat/README.md
@@ -1,67 +1,81 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/llama)
+# Llama-2-chat 70B Truss
 
-# Llama-2 70B Chat Truss
-
-This is a [Truss](https://truss.baseten.co/) for Llama-2 70B Chat. Llama-2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama-2 70B Chat.
+This is a [Truss](https://truss.baseten.co/) for Llama-2-chat 70B. Llama 2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama-2-chat 70B.
 
 ## Truss
 
 Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
-## Deploying Llama-2 70B Chat
+## Setup
 
-To deploy the Llama-2 70B Chat Truss, you'll need to follow these steps:
+[Sign up](https://app.baseten.co/signup) or [sign in](https://app.baseten.co/login/) to your Baseten account and create an [API key](https://app.baseten.co/settings/account/api_keys).
 
-1. __Prerequisites__: Make sure you have a Baseten account and API key. You can sign up for a Baseten account [here](https://app.baseten.co/signup).
+Then run:
 
-2. __Install Truss and the Baseten Python client__: If you haven't already, install the Baseten Python client and Truss in your development environment using:
 ```
-pip install --upgrade baseten truss
+pip install --upgrade baseten
+baseten login
 ```
 
-3. __Set HF API key__: To download the model, you'll need to pass your HF API key and be approved to download weights. Visit this [link](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) to begin the approval process. Once approved, update the `config.yaml` with your Huggingface API key (look for the key, `hf_api_key` in the config.yaml.)
+Paste your API key when prompted.
 
-4. __Load the Llama-2 70B Chat Truss__: Assuming you've cloned this repo, spin up an IPython shell and load the Truss into memory:
-```
+### Get LLaMA-2 access
+
+LLaMA-2 currently requires approval to access. To request access:
+
+1. Go to [https://ai.meta.com/resources/models-and-libraries/llama-downloads/](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and request access using the email associated with your HuggingFace account.
+2. Go to [https://huggingface.co/meta-llama/Llama-2-70B](https://huggingface.co/meta-llama/Llama-2-70B) and request access.
+
+Once you have LLaMA access:
+
+1. Create a [HuggingFace access token](https://huggingface.co/settings/tokens)
+2. Set it as a [secret in your Baseten account](https://app.baseten.co/settings/secrets) with the name `hf_access_token`
+
+## Deployment
+
+In an iPython notebook, run the following script to deploy Llama-2-chat 70B to your Baseten account:
+
+```python
+import baseten
 import truss
 
-llama_2_70b_truss = truss.load("path/to/llama_2_70b_truss")
+llama = truss.load("truss-examples/llama-2-70b-chat/")
+baseten.deploy(
+  llama,
+  model_name="Llama-2-chat 70B",
+  is_trusted=True
+)
 ```
 
-5. __Log in to Baseten__: Log in to your Baseten account using your API key (key found [here](https://app.baseten.co/settings/account/api_keys)):
-```
-import baseten
+Once your Truss is deployed, you can start using the Llama-2-chat 70B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
 
-baseten.login("PASTE_API_KEY_HERE")
-```
+### Hardware notes
 
-6. __Deploy the Llama-2 70B Chat Truss__: Deploy the Llama-2 70B Chat Truss to Baseten with the following command:
-```
-baseten.deploy(llama_2_70b_truss)
-```
+This seventy billion parameter model requires four A100 GPUs.
 
-Once your Truss is deployed, you can start using the Llama-2 70B Chat model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
+## Llama-2-chat 70B API documentation
 
-## Llama-2 70B Chat API documentation
-This section provides an overview of the Llama-2 70B Chat API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+This section provides an overview of the Llama-2-chat 70B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided prompt.
 
 ### API route: `predict`
-The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __instruction__: The input text that you want the model to generate a response for.
+The predict route is the primary method for generating text completions based on a given prompt. It takes several parameters:
+
+- __prompt__: The input text that you want the model to generate a response for.
 - __temperature__ (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
 - __top_p__ (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
 - __top_k__ (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
 - __num_beams__ (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
 
-The API also supports passing any parameter supported by Huggingface's `Transformers.generate`.
+The API also supports passing any parameter supported by HuggingFace's `Transformers.generate`.
 
 ## Example usage
 
 You can use the `baseten` model package to invoke your model from Python
-```
+
+```python
 import baseten
-# You can retrieve your deployed model ID from the UI
+# You can retrieve your deployed model version ID from the Baseten UI
 model = baseten.deployed_model_version_id('YOUR_MODEL_ID')
 
 request = {
@@ -75,9 +89,10 @@ request = {
 response = model.predict(request)
 ```
 
-You can also invoke your model via a REST API
+You can also invoke your model via a REST API:
+
 ```
-curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
+curl -X POST " https://app.baseten.co/model_versions/YOUR_MODEL_VERSION_ID/predict" \
      -H "Content-Type: application/json" \
      -H 'Authorization: Api-Key {YOUR_API_KEY}' \
      -d '{
@@ -87,5 +102,4 @@ curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
            "top_k": 40,
            "num_beams": 4
          }'
-
 ```

--- a/llama-2-70b-chat/config.yaml
+++ b/llama-2-70b-chat/config.yaml
@@ -38,6 +38,6 @@ resources:
   use_gpu: true
   accelerator: A100:2
 secrets:
-  hf_api_key: "ENTER HF API KEY HERE"
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 spec_version: '2.0'
 system_packages: []

--- a/llama-2-70b-chat/examples.yaml
+++ b/llama-2-70b-chat/examples.yaml
@@ -1,4 +1,0 @@
-- input:
-    inputs:
-    - - 0
-  name: example1

--- a/llama-2-70b-chat/model/model.py
+++ b/llama-2-70b-chat/model/model.py
@@ -23,13 +23,13 @@ class Model:
     def load(self):
         self._model = LlamaForCausalLM.from_pretrained(
             "meta-llama/Llama-2-70b-chat-hf", 
-            use_auth_token=self._secrets["hf_api_key"], 
+            use_auth_token=self._secrets["hf_access_token"], 
             device_map="auto",
             torch_dtype=torch.float16,
         )
         self._tokenizer = LlamaTokenizer.from_pretrained(
             "meta-llama/Llama-2-70b-chat-hf", 
-            use_auth_token=self._secrets["hf_api_key"],
+            use_auth_token=self._secrets["hf_access_token"],
             torch_dtype=torch.float16,
         )
 

--- a/llama-2-70b-truss/README.md
+++ b/llama-2-70b-truss/README.md
@@ -1,67 +1,81 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/llama)
+# Llama 2 70B Truss
 
-# LLaMA-2 70B Truss
-
-This is a [Truss](https://truss.baseten.co/) for LLaMA-2 70B Llama-2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of LLaMA-2 70B Chat.
+This is a [Truss](https://truss.baseten.co/) for Llama 2 70B. Llama 2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama 2 70B.
 
 ## Truss
 
-Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
+Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp)). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
-## Deploying LLaMA2-70B
+## Setup
 
-To deploy the LLaMA-2 70B Truss, you'll need to follow these steps:
+[Sign up](https://app.baseten.co/signup) or [sign in](https://app.baseten.co/login/) to your Baseten account and create an [API key](https://app.baseten.co/settings/account/api_keys).
 
-1. __Prerequisites__: Make sure you have a Baseten account and API key. You can sign up for a Baseten account [here](https://app.baseten.co/signup).
+Then run:
 
-2. __Install Truss and the Baseten Python client__: If you haven't already, install the Baseten Python client and Truss in your development environment using:
 ```
-pip install --upgrade baseten truss
+pip install --upgrade baseten
+baseten login
 ```
 
-3. __Set HF API key__: To download the model, you'll need to pass your HF API key and be approved to download weights. Visit this [link](https://huggingface.co/meta-llama/Llama-2-70B-hf) to begin the approval process. Once approved, update the `config.yaml` with your Huggingface API key (look for the key, `hf_api_key` in the config.yaml.)
+Paste your API key when prompted.
 
-4. __Load the LLaMA2-70B Truss__: Assuming you've cloned this repo, spin up an IPython shell and load the Truss into memory:
-```
+### Get Llama 2 access
+
+Llama 2 currently requires approval to access. To request access:
+
+1. Go to [https://ai.meta.com/resources/models-and-libraries/llama-downloads/](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and request access using the email associated with your HuggingFace account.
+2. Go to [https://huggingface.co/meta-llama/Llama-2-70B](https://huggingface.co/meta-llama/Llama-2-70B) and request access.
+
+Once you have Llama access:
+
+1. Create a [HuggingFace access token](https://huggingface.co/settings/tokens)
+2. Set it as a [secret in your Baseten account](https://app.baseten.co/settings/secrets) with the name `hf_access_token`
+
+## Deployment
+
+In an iPython notebook, run the following script to deploy Llama 2 70B to your Baseten account:
+
+```python
+import baseten
 import truss
 
-llama_70B_truss = truss.load("path/to/llama_70B_truss")
+llama = truss.load("truss-examples/llama-2-70b-truss/")
+baseten.deploy(
+  llama,
+  model_name="Llama 2 70B",
+  is_trusted=True
+)
 ```
 
-5. __Log in to Baseten__: Log in to your Baseten account using your API key (key found [here](https://app.baseten.co/settings/account/api_keys)):
-```
-import baseten
+Once your Truss is deployed, you can start using the Llama 2 70B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
 
-baseten.login("PASTE_API_KEY_HERE")
-```
+### Hardware notes
 
-6. __Deploy the LLaMA2-70B Truss__: Deploy the LLaMA2-70B Truss to Baseten with the following command:
-```
-baseten.deploy(llama_70B_truss)
-```
+This seventy billion parameter model requires four A100 GPUs.
 
-Once your Truss is deployed, you can start using the LLaMA2-70B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
+## Llama 2 70B API documentation
 
-## LLaMA2-70B API documentation
-This section provides an overview of the LLaMA2-70B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+This section provides an overview of the Llama 2 70B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided prompt.
 
 ### API route: `predict`
-The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __instruction__: The input text that you want the model to generate a response for.
+The predict route is the primary method for generating text completions based on a given prompt. It takes several parameters:
+
+- __prompt__: The input text that you want the model to generate a response for.
 - __temperature__ (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
 - __top_p__ (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
 - __top_k__ (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
 - __num_beams__ (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
 
-The API also supports passing any parameter supported by Huggingface's `Transformers.generate`.
+The API also supports passing any parameter supported by HuggingFace's `Transformers.generate`.
 
 ## Example usage
 
 You can use the `baseten` model package to invoke your model from Python
-```
+
+```python
 import baseten
-# You can retrieve your deployed model ID from the UI
+# You can retrieve your deployed model version ID from the Baseten UI
 model = baseten.deployed_model_version_id('YOUR_MODEL_ID')
 
 request = {
@@ -75,9 +89,10 @@ request = {
 response = model.predict(request)
 ```
 
-You can also invoke your model via a REST API
+You can also invoke your model via a REST API:
+
 ```
-curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
+curl -X POST " https://app.baseten.co/model_versions/YOUR_MODEL_VERSION_ID/predict" \
      -H "Content-Type: application/json" \
      -H 'Authorization: Api-Key {YOUR_API_KEY}' \
      -d '{
@@ -87,5 +102,4 @@ curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
            "top_k": 40,
            "num_beams": 4
          }'
-
 ```

--- a/llama-2-70b-truss/examples.yaml
+++ b/llama-2-70b-truss/examples.yaml
@@ -1,4 +1,0 @@
-- input:
-    inputs:
-    - - 0
-  name: example1

--- a/llama-2-7b-chat/README.md
+++ b/llama-2-7b-chat/README.md
@@ -1,67 +1,81 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/llama)
+# Llama-2-chat 7B Truss
 
-# LLaMA-2 7B Chat Truss
-
-This is a [Truss](https://truss.baseten.co/) for LLaMA-2 7B Chat. Llama-2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of LLaMA-2 7B Chat.
+This is a [Truss](https://truss.baseten.co/) for Llama-2-chat 7B. Llama 2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama-2-chat 7B.
 
 ## Truss
 
-Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
+Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp)). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
-## Deploying LLaMA2-7B Chat
+## Setup
 
-To deploy the LLaMA-2 7B Chat Truss, you'll need to follow these steps:
+[Sign up](https://app.baseten.co/signup) or [sign in](https://app.baseten.co/login/) to your Baseten account and create an [API key](https://app.baseten.co/settings/account/api_keys).
 
-1. __Prerequisites__: Make sure you have a Baseten account and API key. You can sign up for a Baseten account [here](https://app.baseten.co/signup).
+Then run:
 
-2. __Install Truss and the Baseten Python client__: If you haven't already, install the Baseten Python client and Truss in your development environment using:
 ```
-pip install --upgrade baseten truss
+pip install --upgrade baseten
+baseten login
 ```
 
-3. __Set HF API key__: To download the model, you'll need to pass your HF API key and be approved to download weights. Visit this [link](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) to begin the approval process. Once approved, update the `config.yaml` with your Huggingface API key (look for the key, `hf_api_key` in the config.yaml.)
+Paste your API key when prompted.
 
-4. __Load the LLaMA2-7B Chat Truss__: Assuming you've cloned this repo, spin up an IPython shell and load the Truss into memory:
-```
+### Get Llama 2 access
+
+Llama 2 currently requires approval to access. To request access:
+
+1. Go to [https://ai.meta.com/resources/models-and-libraries/llama-downloads/](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and request access using the email associated with your HuggingFace account.
+2. Go to [https://huggingface.co/meta-llama/Llama-2-7b](https://huggingface.co/meta-llama/Llama-2-7b) and request access.
+
+Once you have Llama access:
+
+1. Create a [HuggingFace access token](https://huggingface.co/settings/tokens)
+2. Set it as a [secret in your Baseten account](https://app.baseten.co/settings/secrets) with the name `hf_access_token`
+
+## Deployment
+
+In an iPython notebook, run the following script to deploy Llama-2-chat 7B to your Baseten account:
+
+```python
+import baseten
 import truss
 
-llama_7b_truss = truss.load("path/to/llama_7b_truss")
+llama = truss.load("truss-examples/llama-2-7b-chat/")
+baseten.deploy(
+  llama,
+  model_name="Llama-2-chat 7B",
+  is_trusted=True
+)
 ```
 
-5. __Log in to Baseten__: Log in to your Baseten account using your API key (key found [here](https://app.baseten.co/settings/account/api_keys)):
-```
-import baseten
+Once your Truss is deployed, you can start using the Llama-2-chat 7B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
 
-baseten.login("PASTE_API_KEY_HERE")
-```
+### Hardware notes
 
-6. __Deploy the LLaMA2-7B Chat Truss__: Deploy the LLaMA2-7B Chat Truss to Baseten with the following command:
-```
-baseten.deploy(llama_7b_truss)
-```
+This seven billion parameter model is running in `float16` so that it fits on an A10G.
 
-Once your Truss is deployed, you can start using the LLaMA2-7B Chat model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
+## Llama-2-chat 7B API documentation
 
-## LLaMA2-7B Chat API documentation
-This section provides an overview of the LLaMA2-7B Chat API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+This section provides an overview of the Llama-2-chat 7B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided prompt.
 
 ### API route: `predict`
-The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __instruction__: The input text that you want the model to generate a response for.
+The predict route is the primary method for generating text completions based on a given prompt. It takes several parameters:
+
+- __prompt__: The input text that you want the model to generate a response for.
 - __temperature__ (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
 - __top_p__ (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
 - __top_k__ (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
 - __num_beams__ (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
 
-The API also supports passing any parameter supported by Huggingface's `Transformers.generate`.
+The API also supports passing any parameter supported by HuggingFace's `Transformers.generate`.
 
 ## Example usage
 
 You can use the `baseten` model package to invoke your model from Python
-```
+
+```python
 import baseten
-# You can retrieve your deployed model ID from the UI
+# You can retrieve your deployed model version ID from the Baseten UI
 model = baseten.deployed_model_version_id('YOUR_MODEL_ID')
 
 request = {
@@ -75,9 +89,10 @@ request = {
 response = model.predict(request)
 ```
 
-You can also invoke your model via a REST API
+You can also invoke your model via a REST API:
+
 ```
-curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
+curl -X POST " https://app.baseten.co/model_versions/YOUR_MODEL_VERSION_ID/predict" \
      -H "Content-Type: application/json" \
      -H 'Authorization: Api-Key {YOUR_API_KEY}' \
      -d '{
@@ -87,5 +102,4 @@ curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
            "top_k": 40,
            "num_beams": 4
          }'
-
 ```

--- a/llama-2-7b-chat/config.yaml
+++ b/llama-2-7b-chat/config.yaml
@@ -16,7 +16,7 @@ model_metadata:
   tags:
   - text-generation
 model_module_dir: model
-model_name: LLaMA 2 7B Chat
+model_name: Llama-2-chat 7B
 model_type: custom
 python_version: py38
 requirements:
@@ -36,8 +36,8 @@ resources:
   cpu: "3"
   memory: 14Gi
   use_gpu: true
-  accelerator: A100
+  accelerator: A10G
 secrets:
-  hf_api_key: "ENTER HF API KEY HERE"
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 spec_version: '2.0'
 system_packages: []

--- a/llama-2-7b-chat/examples.yaml
+++ b/llama-2-7b-chat/examples.yaml
@@ -1,4 +1,0 @@
-- input:
-    inputs:
-    - - 0
-  name: example1

--- a/llama-2-7b-chat/model/model.py
+++ b/llama-2-7b-chat/model/model.py
@@ -23,12 +23,13 @@ class Model:
     def load(self):
         self._model = LlamaForCausalLM.from_pretrained(
             "meta-llama/Llama-2-7b-chat-hf", 
-            use_auth_token=self._secrets["hf_api_key"], 
+            use_auth_token=self._secrets["hf_access_token"], 
+            torch_dtype=torch.float16,
             device_map="auto"
         )
         self._tokenizer = LlamaTokenizer.from_pretrained(
             "meta-llama/Llama-2-7b-chat-hf", 
-            use_auth_token=self._secrets["hf_api_key"]
+            use_auth_token=self._secrets["hf_access_token"]
         )
 
     def preprocess(self, request: Dict) -> Dict:

--- a/llama-2-7b-truss/README.md
+++ b/llama-2-7b-truss/README.md
@@ -1,67 +1,81 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/llama)
+# Llama 2 7B Truss
 
-# LLaMA-2 7B Truss
-
-This is a [Truss](https://truss.baseten.co/) for LLaMA-2 7B Llama-2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of LLaMA-2 7B Chat.
+This is a [Truss](https://truss.baseten.co/) for Llama 2 7B. Llama 2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama 2 7B.
 
 ## Truss
 
-Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
+Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp)). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
-## Deploying LLaMA2-7B
+## Setup
 
-To deploy the LLaMA-2 7B Truss, you'll need to follow these steps:
+[Sign up](https://app.baseten.co/signup) or [sign in](https://app.baseten.co/login/) to your Baseten account and create an [API key](https://app.baseten.co/settings/account/api_keys).
 
-1. __Prerequisites__: Make sure you have a Baseten account and API key. You can sign up for a Baseten account [here](https://app.baseten.co/signup).
+Then run:
 
-2. __Install Truss and the Baseten Python client__: If you haven't already, install the Baseten Python client and Truss in your development environment using:
 ```
-pip install --upgrade baseten truss
+pip install --upgrade baseten
+baseten login
 ```
 
-3. __Set HF API key__: To download the model, you'll need to pass your HF API key and be approved to download weights. Visit this [link](https://huggingface.co/meta-llama/Llama-2-7b-hf) to begin the approval process. Once approved, update the `config.yaml` with your Huggingface API key (look for the key, `hf_api_key` in the config.yaml.)
+Paste your API key when prompted.
 
-4. __Load the LLaMA2-7B Truss__: Assuming you've cloned this repo, spin up an IPython shell and load the Truss into memory:
-```
+### Get Llama 2 access
+
+Llama 2 currently requires approval to access. To request access:
+
+1. Go to [https://ai.meta.com/resources/models-and-libraries/llama-downloads/](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and request access using the email associated with your HuggingFace account.
+2. Go to [https://huggingface.co/meta-llama/Llama-2-7b](https://huggingface.co/meta-llama/Llama-2-7b) and request access.
+
+Once you have Llama access:
+
+1. Create a [HuggingFace access token](https://huggingface.co/settings/tokens)
+2. Set it as a [secret in your Baseten account](https://app.baseten.co/settings/secrets) with the name `hf_access_token`
+
+## Deployment
+
+In an iPython notebook, run the following script to deploy Llama 2 7B to your Baseten account:
+
+```python
+import baseten
 import truss
 
-llama_7b_truss = truss.load("path/to/llama_7b_truss")
+llama = truss.load("truss-examples/llama-2-7b-truss/")
+baseten.deploy(
+  llama,
+  model_name="Llama 2 7B",
+  is_trusted=True
+)
 ```
 
-5. __Log in to Baseten__: Log in to your Baseten account using your API key (key found [here](https://app.baseten.co/settings/account/api_keys)):
-```
-import baseten
+Once your Truss is deployed, you can start using the Llama 2 7B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
 
-baseten.login("PASTE_API_KEY_HERE")
-```
+### Hardware notes
 
-6. __Deploy the LLaMA2-7B Truss__: Deploy the LLaMA2-7B Truss to Baseten with the following command:
-```
-baseten.deploy(llama_7b_truss)
-```
+This seven billion parameter model is running in `float16` so that it fits on an A10G.
 
-Once your Truss is deployed, you can start using the LLaMA2-7B model through the Baseten platform! Navigate to the Baseten UI to watch the model build and deploy and invoke it via the REST API.
+## Llama 2 7B API documentation
 
-## LLaMA2-7B API documentation
-This section provides an overview of the LLaMA2-7B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+This section provides an overview of the Llama 2 7B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided prompt.
 
 ### API route: `predict`
-The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __instruction__: The input text that you want the model to generate a response for.
+The predict route is the primary method for generating text completions based on a given prompt. It takes several parameters:
+
+- __prompt__: The input text that you want the model to generate a response for.
 - __temperature__ (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
 - __top_p__ (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
 - __top_k__ (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
 - __num_beams__ (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
 
-The API also supports passing any parameter supported by Huggingface's `Transformers.generate`.
+The API also supports passing any parameter supported by HuggingFace's `Transformers.generate`.
 
 ## Example usage
 
 You can use the `baseten` model package to invoke your model from Python
-```
+
+```python
 import baseten
-# You can retrieve your deployed model ID from the UI
+# You can retrieve your deployed model version ID from the Baseten UI
 model = baseten.deployed_model_version_id('YOUR_MODEL_ID')
 
 request = {
@@ -75,9 +89,10 @@ request = {
 response = model.predict(request)
 ```
 
-You can also invoke your model via a REST API
+You can also invoke your model via a REST API:
+
 ```
-curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
+curl -X POST " https://app.baseten.co/model_versions/YOUR_MODEL_VERSION_ID/predict" \
      -H "Content-Type: application/json" \
      -H 'Authorization: Api-Key {YOUR_API_KEY}' \
      -d '{
@@ -87,5 +102,4 @@ curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
            "top_k": 40,
            "num_beams": 4
          }'
-
 ```

--- a/llama-2-7b-truss/config.yaml
+++ b/llama-2-7b-truss/config.yaml
@@ -30,8 +30,8 @@ resources:
   cpu: "3"
   memory: 14Gi
   use_gpu: true
-  accelerator: A100:1
+  accelerator: A10G
 secrets:
-  hf_token: null
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 spec_version: '2.0'
 system_packages: []

--- a/llama-2-7b-truss/examples.yaml
+++ b/llama-2-7b-truss/examples.yaml
@@ -1,4 +1,0 @@
-- input:
-    inputs:
-    - - 0
-  name: example1

--- a/llama-2-7b-truss/model/model.py
+++ b/llama-2-7b-truss/model/model.py
@@ -13,7 +13,7 @@ class Model:
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.tokenizer = None
         self.pipeline = None
-        self.hf_token = kwargs["secrets"]["hf_token"]
+        self.hf_token = kwargs["secrets"]["hf_access_token"]
 
     def preprocess(self, request: dict):
         generate_args = {
@@ -43,6 +43,7 @@ class Model:
         self.model = LlamaForCausalLM.from_pretrained(
             CHECKPOINT,
             use_auth_token=self.hf_token,
+            torch_dtype=torch.float16,
             device_map="auto")
 
         self.tokenizer = LlamaTokenizer.from_pretrained(


### PR DESCRIPTION
This PR:

1. Updates the 7B models to run in `float16` on an A10G like the rest of our 7B parameter LLMs rather than on an A100.
2. Standardizes on `hf_access_token` for consistency with our docs and product, as well as HuggingFace's naming.
3. Updates the READMEs of the 6 Llama 2 models to have corrected and clarified deployment instructions.
4. Updates the READMEs of the 6 Llama 2 models to use the same punctuation and capitalization as Meta uses.
5. Removes unneeded `examples.yaml` files