### PR TITLE
Update Memory Requirements for Mistral

### DIFF
--- a/mistral/mistral-7b-instruct-vllm/config.yaml
+++ b/mistral/mistral-7b-instruct-vllm/config.yaml
@@ -18,5 +18,6 @@ python_version: py311
 resources:
   accelerator: A10G
   use_gpu: true
+  memory: 25Gi
 secrets: {}
 system_packages: []

--- a/mistral/mistral-7b-instruct/config.yaml
+++ b/mistral/mistral-7b-instruct/config.yaml
@@ -20,5 +20,6 @@ requirements:
 resources:
   accelerator: A10G
   use_gpu: true
+  memory: 25Gi
 secrets: {}
 system_packages: []

--- a/mistral/mistral-7b/config.yaml
+++ b/mistral/mistral-7b/config.yaml
@@ -11,5 +11,6 @@ requirements:
 resources:
   accelerator: A10G
   use_gpu: true
+  memory: 25Gi
 secrets: {}
 system_packages: []


### PR DESCRIPTION
The Mistral 7B model doesn't run on our smallest A10G instance since there isn't enough memory available. This PR updates the `config.yml` to the next largest instance.