### PR TITLE
Fix mistral-7B models in examples

### DIFF
--- a/ci.yaml
+++ b/ci.yaml
@@ -7,3 +7,5 @@ tests:
   - 06-high-performance-cached-weights
   - 07-high-performance-tgi
   - 10-using-system-packages
+  - mistral/mistral-7b
+  - mistral/mistral-7b-instruct

--- a/mistral/mistral-7b-instruct/model/model.py
+++ b/mistral/mistral-7b-instruct/model/model.py
@@ -13,7 +13,7 @@ class Model:
             torch_dtype=torch.float16,
             device_map="auto")
 
-        self.tokenizer = AutoModelForCausalLM.from_pretrained(
+        self.tokenizer = AutoTokenizer.from_pretrained(
             "mistralai/Mistral-7B-Instruct-v0.1",
             device_map="auto",
             torch_dtype=torch.float16,

--- a/mistral/mistral-7b/config.yaml
+++ b/mistral/mistral-7b/config.yaml
@@ -1,6 +1,12 @@
 environment_variables: {}
 external_package_dirs: []
-model_metadata: {}
+model_metadata:
+  example_model_input: {"prompt": "What is the Mistral wind?"}
+  pretty_name: Mistral 7B
+  avatar_url: https://cdn.baseten.co/production/static/explore/mistral_logo.png
+  cover_image_url: https://cdn.baseten.co/production/static/explore/mistral.png
+  tags:
+  - text-generation
 model_name: mistral-7b
 python_version: py311
 requirements:

--- a/mistral/mistral-7b/model/model.py
+++ b/mistral/mistral-7b/model/model.py
@@ -15,7 +15,7 @@ class Model:
             torch_dtype=torch.float16,
             device_map="auto")
 
-        self.tokenizer = AutoModelForCausalLM.from_pretrained(
+        self.tokenizer = AutoTokenizer.from_pretrained(
             "mistralai/Mistral-7B-v0.1",
             device_map="auto",
             torch_dtype=torch.float16,


### PR DESCRIPTION
I've discovered that mistral-7B model doesn't work currently due to typo and using model class instead of tokenizer in `model.py`.

I've fixed this, as well as enabled two mistral models on ci tests to catch this error next time. 