### PR TITLE
Run CI on python 3.11.4.

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.11.4'
       - name: Install dependencies (if any)
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Hardcode the python version. Python 3.12 released, and this used that, but truss currently does not support python 3.12.