### PR TITLE
Add truss example for DeepSpeed MII with Llama2 7B chat model 

### DIFF
--- a/deepspeed-mii/README.md
+++ b/deepspeed-mii/README.md
@@ -1,0 +1,76 @@
+# Llama-2-chat 7B DeepSpeed MII Truss
+
+This is a [Truss](https://truss.baseten.co/) for Llama-2-chat 7B served with [DeepSpeed MII](https://github.com/microsoft/DeepSpeed-MII). Llama 2 is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Llama-2-chat 7B.
+
+## Truss
+
+Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp)). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
+
+### Get Llama 2 access
+
+Llama 2 currently requires approval to access. To request access:
+
+1. Go to [https://ai.meta.com/resources/models-and-libraries/llama-downloads/](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and request access using the email associated with your HuggingFace account.
+2. Go to [https://huggingface.co/meta-llama/Llama-2-7b](https://huggingface.co/meta-llama/Llama-2-7b) and request access.
+
+Once you have Llama access:
+
+1. Create a [HuggingFace access token](https://huggingface.co/settings/tokens)
+2. Set it as a [secret in your Baseten account](https://app.baseten.co/settings/secrets) with the name `hf_access_token`
+
+## Deployment
+
+First, clone this repository:
+
+```sh
+git clone https://github.com/basetenlabs/truss-examples/
+cd deepspeed-mii
+```
+
+Before deployment:
+
+1. Make sure you have a [Baseten account](https://app.baseten.co/signup) and [API key](https://app.baseten.co/settings/account/api_keys).
+2. Install the latest version of Truss: `pip install --upgrade truss`
+
+With `deepspeed-mii` as your working directory, you can deploy the model with:
+
+```sh
+truss push --trusted
+```
+
+Paste your Baseten API key if prompted.
+
+For more information, see [Truss documentation](https://truss.baseten.co).
+
+### Hardware notes
+
+This seven billion parameter model is running in `float16` so that it fits on an A10G.
+
+## Llama-2-chat 7B API documentation
+
+This section provides an overview of the Llama-2-chat 7B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided prompt.
+
+### API route: `predict`
+
+The predict route is the primary method for generating text completions based on a given prompt. It takes several parameters:
+
+- __prompt__: The input text that you want the model to generate a response for.
+- __max_length__ (optional, default=512): The maximum number of tokens to return, counting input tokens. Maximum of 4096.
+
+## Example usage
+
+```sh
+truss predict -d '{"prompt": "What is the meaning of life?", "max_length": 1024}'
+```
+
+You can also invoke your model via a REST API:
+
+```
+curl -X POST " https://app.baseten.co/model_versions/YOUR_MODEL_VERSION_ID/predict" \
+     -H "Content-Type: application/json" \
+     -H 'Authorization: Api-Key {YOUR_API_KEY}' \
+     -d '{
+           "prompt": "What's the meaning of life?",
+           "max_length": 1024
+         }'
+```

--- a/deepspeed-mii/config.yaml
+++ b/deepspeed-mii/config.yaml
@@ -13,7 +13,12 @@ model_class_filename: model.py
 model_class_name: Model
 model_framework: custom
 model_metadata:
+  # huggingface repo or folder with model files
   repo_id: meta-llama/Llama-2-7b-chat-hf
+  # increase `max_length` if you need to support larger inputs/outputs
+  max_length: 4096
+  # increase `tensor_parallel` to use more than one GPU
+  tensor_parallel: 1
   example_model_input: {"prompt": "What's the meaning of life?", "max_length": 1024}
   avatar_url: https://cdn.baseten.co/production/static/explore/meta.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png

--- a/deepspeed-mii/config.yaml
+++ b/deepspeed-mii/config.yaml
@@ -1,17 +1,8 @@
 spec_version: '2.0'
 base_image:
   image: baseten/truss-server-base:3.11-gpu-v0.7.15
-bundled_packages_dir: packages
-data_dir: data
+model_name: Llama-2-chat 7B DeepSpeed MII
 description: Generate text from a prompt with this seven billion parameter language model.
-environment_variables: {}
-examples_filename: examples.yaml
-external_package_dirs: []
-input_type: Any
-live_reload: false
-model_class_filename: model.py
-model_class_name: Model
-model_framework: custom
 model_metadata:
   # huggingface repo or folder with model files
   repo_id: meta-llama/Llama-2-7b-chat-hf
@@ -24,9 +15,6 @@ model_metadata:
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png
   tags:
   - text-generation
-model_module_dir: model
-model_name: Llama-2-chat 7B deepspeed
-model_type: custom
 python_version: py311
 requirements:
 - deepspeed-mii==0.1.0

--- a/deepspeed-mii/config.yaml
+++ b/deepspeed-mii/config.yaml
@@ -1,0 +1,43 @@
+spec_version: '2.0'
+base_image:
+  image: baseten/truss-server-base:3.11-gpu-v0.7.15
+bundled_packages_dir: packages
+data_dir: data
+description: Generate text from a prompt with this seven billion parameter language model.
+environment_variables: {}
+examples_filename: examples.yaml
+external_package_dirs: []
+input_type: Any
+live_reload: false
+model_class_filename: model.py
+model_class_name: Model
+model_framework: custom
+model_metadata:
+  repo_id: meta-llama/Llama-2-7b-chat-hf
+  example_model_input: {"prompt": "What's the meaning of life?", "max_length": 1024}
+  avatar_url: https://cdn.baseten.co/production/static/explore/meta.png
+  cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png
+  tags:
+  - text-generation
+model_module_dir: model
+model_name: Llama-2-chat 7B deepspeed
+model_type: custom
+python_version: py311
+requirements:
+- deepspeed-mii==0.1.0
+resources:
+  cpu: "3"
+  memory: 14Gi
+  use_gpu: true
+  accelerator: A100
+secrets:
+  hf_access_token: null
+system_packages:
+- cuda-toolkit-12-2
+runtime:
+  predict_concurrency: 256
+hf_cache:
+  - repo_id: meta-llama/Llama-2-7b-chat-hf
+    allow_patterns:
+      - "*.json"
+      - "*.bin"

--- a/deepspeed-mii/model/model.py
+++ b/deepspeed-mii/model/model.py
@@ -6,19 +6,25 @@ from huggingface_hub import login
 
 DEFAULT_RESPONSE_MAX_LENGTH = 512
 
+
 class Model:
     def __init__(self, **kwargs) -> None:
         self.hf_access_token = kwargs["secrets"]["hf_access_token"]
-        self.repo_id = kwargs["config"]["model_metadata"]["repo_id"]
-        self.max_length = int(kwargs["config"]["model_metadata"]["max_length"])
-        self.tensor_parallel = int(kwargs["config"]["model_metadata"]["tensor_parallel"])
+        model_metadata = kwargs["config"]["model_metadata"]
+        self.repo_id = model_metadata["repo_id"]
+        self.max_length = int(model_metadata["max_length"])
+        self.tensor_parallel = int(model_metadata["tensor_parallel"])
 
     def load(self):
         login(token=self.hf_access_token)
         # need to create a new loop because `mii.serve` creates async client at the end,
         # and `load` function being called from new thread
         asyncio.set_event_loop(asyncio.new_event_loop())
-        mii.serve(self.repo_id, tensor_parallel=self.tensor_parallel, max_length=self.max_length)
+        mii.serve(
+            self.repo_id,
+            tensor_parallel=self.tensor_parallel,
+            max_length=self.max_length,
+        )
 
     def predict(self, request: Dict):
         # we need to create new asyncio loop because each request is being server from new thread

--- a/deepspeed-mii/model/model.py
+++ b/deepspeed-mii/model/model.py
@@ -5,34 +5,26 @@ import mii
 from huggingface_hub import login
 
 DEFAULT_RESPONSE_MAX_LENGTH = 512
-MAX_LENGTH = 4096
-
 
 class Model:
     def __init__(self, **kwargs) -> None:
         self.hf_access_token = kwargs["secrets"]["hf_access_token"]
-        self.repo = kwargs["config"]["model_metadata"]["repo_id"]
+        self.repo_id = kwargs["config"]["model_metadata"]["repo_id"]
+        self.max_length = int(kwargs["config"]["model_metadata"]["max_length"])
+        self.tensor_parallel = int(kwargs["config"]["model_metadata"]["tensor_parallel"])
 
     def load(self):
         login(token=self.hf_access_token)
         # need to create a new loop because `mii.serve` creates async client at the end,
         # and `load` function being called from new thread
         asyncio.set_event_loop(asyncio.new_event_loop())
-        #
-        mii.serve(
-            # huggingface repo or folder with model files
-            self.repo,
-            # increase `tensor_parallel` to use more than one GPU
-            tensor_parallel=1,
-            # increase `max_length` if you need to support larger inputs/outputs
-            max_length=MAX_LENGTH,
-        )
+        mii.serve(self.repo_id, tensor_parallel=self.tensor_parallel, max_length=self.max_length)
 
     def predict(self, request: Dict):
         # we need to create new asyncio loop because each request is being server from new thread
         new_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(new_loop)
-        client = mii.client(self.repo)
+        client = mii.client(self.repo_id)
         response = client.generate(
             request.pop("prompt"),
             max_new_tokens=request.pop("max_length", DEFAULT_RESPONSE_MAX_LENGTH),

--- a/deepspeed-mii/model/model.py
+++ b/deepspeed-mii/model/model.py
@@ -1,0 +1,40 @@
+from typing import Dict
+import mii
+import asyncio
+from huggingface_hub import login
+
+DEFAULT_RESPONSE_MAX_LENGTH = 512
+MAX_LENGTH = 4096
+
+class Model:
+    def __init__(self, **kwargs) -> None:
+        self.hf_access_token = kwargs["secrets"]["hf_access_token"]
+        self.repo = kwargs["config"]["model_metadata"]["repo_id"]
+
+    def load(self):
+        login(token=self.hf_access_token)
+        # need to create a new loop because `mii.serve` creates async client at the end,
+        # and `load` function being called from new thread
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        #
+        mii.serve(
+            # huggingface repo or folder with model files
+            self.repo,
+            # increase `tensor_parallel` to use more than one GPU
+            tensor_parallel=1,
+            # increase `max_length` if you need to support larger inputs/outputs
+            max_length=MAX_LENGTH
+        )
+
+    def predict(self, request: Dict):
+        # we need to create new asyncio loop because each request is being server from new thread
+        new_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(new_loop)
+        client = mii.client(self.repo)
+        response = client.generate(
+            request.pop("prompt"),
+            max_new_tokens=request.pop("max_length", DEFAULT_RESPONSE_MAX_LENGTH)
+        )
+        new_loop.close()
+
+        return '\n'.join(response.response)

--- a/deepspeed-mii/model/model.py
+++ b/deepspeed-mii/model/model.py
@@ -1,6 +1,7 @@
-from typing import Dict
-import mii
 import asyncio
+from typing import Dict
+
+import mii
 from huggingface_hub import login
 
 DEFAULT_RESPONSE_MAX_LENGTH = 512

--- a/deepspeed-mii/model/model.py
+++ b/deepspeed-mii/model/model.py
@@ -6,6 +6,7 @@ from huggingface_hub import login
 DEFAULT_RESPONSE_MAX_LENGTH = 512
 MAX_LENGTH = 4096
 
+
 class Model:
     def __init__(self, **kwargs) -> None:
         self.hf_access_token = kwargs["secrets"]["hf_access_token"]
@@ -23,7 +24,7 @@ class Model:
             # increase `tensor_parallel` to use more than one GPU
             tensor_parallel=1,
             # increase `max_length` if you need to support larger inputs/outputs
-            max_length=MAX_LENGTH
+            max_length=MAX_LENGTH,
         )
 
     def predict(self, request: Dict):
@@ -33,8 +34,8 @@ class Model:
         client = mii.client(self.repo)
         response = client.generate(
             request.pop("prompt"),
-            max_new_tokens=request.pop("max_length", DEFAULT_RESPONSE_MAX_LENGTH)
+            max_new_tokens=request.pop("max_length", DEFAULT_RESPONSE_MAX_LENGTH),
         )
         new_loop.close()
 
-        return '\n'.join(response.response)
+        return "\n".join(response.response)


### PR DESCRIPTION
This adds Llama2 7B chat model served with [Microsoft's DeepSpeed MII](https://github.com/microsoft/DeepSpeed-MII) framework.