### PR TITLE
Add `ignore_eos` support to deep-speed and trt-llm backends

### DIFF
--- a/deepspeed-mii/config.yaml
+++ b/deepspeed-mii/config.yaml
@@ -15,7 +15,7 @@ model_metadata:
   - text-generation
 python_version: py311
 requirements:
-- deepspeed-mii==0.1.0
+- deepspeed-mii==0.1.1
 resources:
   cpu: "3"
   memory: 14Gi

--- a/deepspeed-mii/model/model.py
+++ b/deepspeed-mii/model/model.py
@@ -43,7 +43,8 @@ class Model:
     def predict(self, request: Dict):
         prompt = request.pop("prompt")
         generate_args = {
-            "max_new_tokens": request.pop("max_length", DEFAULT_RESPONSE_MAX_LENGTH)
+            "max_new_tokens": request.pop("max_length", DEFAULT_RESPONSE_MAX_LENGTH),
+            "ignore_eos": request.pop("ignore_eos", False),
         }
 
         if request.pop("stream", False):

--- a/llama/llama-2-7b-trt-llm/model/model.py
+++ b/llama/llama-2-7b-trt-llm/model/model.py
@@ -1,10 +1,10 @@
 from itertools import count
 from pathlib import Path
 from threading import Thread
-from transformers import AutoTokenizer
 
 import numpy as np
 from client import TritonClient, UserData
+from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
 
 TRITON_MODEL_REPOSITORY_PATH = Path("/packages/inflight_batcher_llm/")
@@ -45,14 +45,16 @@ class Model:
 
         # Load Triton Server and model
         tokenizer_repository = self._config["model_metadata"]["tokenizer_repository"]
-        env = { "triton_tokenizer_repository": tokenizer_repository }
+        env = {"triton_tokenizer_repository": tokenizer_repository}
         if hf_access_token is not None:
             env["HUGGING_FACE_HUB_TOKEN"] = hf_access_token
 
         self.triton_client.load_server_and_model(env=env)
 
         # setup eos token
-        tokenizer = AutoTokenizer.from_pretrained(tokenizer_repository, token = hf_access_token)
+        tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_repository, token=hf_access_token
+        )
         self.eos_token_id = tokenizer.eos_token_id
 
     def predict(self, model_input):

--- a/llama/llama-2-7b-trt-llm/model/model.py
+++ b/llama/llama-2-7b-trt-llm/model/model.py
@@ -92,8 +92,7 @@ class Model:
         ]
 
         if not ignore_eos:
-            end_id = [[self.eos_token_id]]
-            end_id_data = np.array(end_id, dtype=np.uint32)
+            end_id_data = np.array([[self.eos_token_id]], dtype=np.uint32)
             inputs.append(prepare_grpc_tensor("end_id", end_id_data))
         else:
             # do nothing, trt-llm by default doesn't stop on `eos`


### PR DESCRIPTION
In order to make benchmarks more apples-to-apples it would be useful to have an ability to keep generating output even if `eos` token was emitted. I've added support for that to deep speed and trt-llm backends. 