### PR TITLE
Add ability to specify engine args to mistral vllm implementation

### DIFF
--- a/mistral/mistral-7b-instruct-vllm/config.yaml
+++ b/mistral/mistral-7b-instruct-vllm/config.yaml
@@ -1,6 +1,7 @@
 description: Generate text with an instruction-tuned version of Mistral 7B.
 model_metadata:
-  repo_id: mistralai/Mistral-7B-Instruct-v0.1
+  engine_args:
+    model: mistralai/Mistral-7B-Instruct-v0.1
   prompt_format: <s>[INST] {prompt} [/INST]
   example_model_input: {"prompt": "What is the Mistral wind?"}
   pretty_name: Mistral 7B Instruct

--- a/mistral/mistral-7b-instruct-vllm/model/model.py
+++ b/mistral/mistral-7b-instruct-vllm/model/model.py
@@ -8,14 +8,11 @@ from vllm.engine.async_llm_engine import AsyncLLMEngine
 
 class Model:
     def __init__(self, **kwargs) -> None:
-        self.model_args = None
-        self.llm_engine = None
-        self.repo_id = kwargs["config"]["model_metadata"]["repo_id"]
+        self.engine_args = kwargs["config"]["model_metadata"]["engine_args"]
         self.prompt_format = kwargs["config"]["model_metadata"]["prompt_format"]
 
     def load(self) -> None:
-        self.model_args = AsyncEngineArgs(model=self.repo_id)
-        self.llm_engine = AsyncLLMEngine.from_engine_args(self.model_args)
+        self.llm_engine = AsyncLLMEngine.from_engine_args(AsyncEngineArgs(**self.engine_args))
 
     async def predict(self, request: dict) -> Any:
         prompt = request.pop("prompt")

--- a/mistral/mistral-7b-instruct-vllm/model/model.py
+++ b/mistral/mistral-7b-instruct-vllm/model/model.py
@@ -12,7 +12,9 @@ class Model:
         self.prompt_format = kwargs["config"]["model_metadata"]["prompt_format"]
 
     def load(self) -> None:
-        self.llm_engine = AsyncLLMEngine.from_engine_args(AsyncEngineArgs(**self.engine_args))
+        self.llm_engine = AsyncLLMEngine.from_engine_args(
+            AsyncEngineArgs(**self.engine_args)
+        )
 
     async def predict(self, request: dict) -> Any:
         prompt = request.pop("prompt")


### PR DESCRIPTION
In order to enable customization of max length supported by engine we need to be able to pass arbitrary config params to vllm engine. Currently we support only passing `repo_id`, I've changed it to `engine_args` with `model` being repo (since that's how vllm engine arg is called).