### PR TITLE
Add model server build config  

### DIFF
--- a/llama/llama-2-7b-trt-llm/README.md
+++ b/llama/llama-2-7b-trt-llm/README.md
@@ -8,7 +8,7 @@ This is a [Truss](https://truss.baseten.co/) for an int8 SmoothQuant version of 
 
 ## Truss
 
-Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
+Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten. Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
 ## Deploying LLaMA2-7B-Chat
 

--- a/llama/llama-2-7b-trt-llm/config.yaml
+++ b/llama/llama-2-7b-trt-llm/config.yaml
@@ -16,7 +16,6 @@ model_metadata:
   tokenizer_repository: "NousResearch/Llama-2-7b-chat-hf"
 description: Generate text from a prompt with this seven billion parameter language model.
 model_name: Llama 7B Chat TRT
-
 python_version: py311
 requirements:
 - tritonclient[all]

--- a/llama/llama-2-7b-trt-llm/config.yaml
+++ b/llama/llama-2-7b-trt-llm/config.yaml
@@ -1,6 +1,8 @@
 base_image:
   image: nvcr.io/nvidia/tritonserver:23.10-trtllm-python-py3
   python_executable_path: /usr/bin/python3
+build:
+  model_server: TRT_LLM
 environment_variables: {}
 external_package_dirs: []
 model_metadata:
@@ -14,6 +16,7 @@ model_metadata:
   tokenizer_repository: "NousResearch/Llama-2-7b-chat-hf"
 description: Generate text from a prompt with this seven billion parameter language model.
 model_name: Llama 7B Chat TRT
+
 python_version: py311
 requirements:
 - tritonclient[all]

--- a/mistral/mistral-7b-trt-llm/README.md
+++ b/mistral/mistral-7b-trt-llm/README.md
@@ -8,7 +8,7 @@ This is a [Truss](https://truss.baseten.co/) for Mistral 7B. This README will wa
 
 ## Truss
 
-Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
+Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten. Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
 ## Deploying Mistral-7B
 

--- a/mistral/mistral-7b-trt-llm/config.yaml
+++ b/mistral/mistral-7b-trt-llm/config.yaml
@@ -23,7 +23,6 @@ resources:
   accelerator: A100
   use_gpu: true
 secrets: {}
-system_packages:
-- python3.10-venv
+system_packages: []
 runtime:
   predict_concurrency: 256

--- a/mistral/mistral-7b-trt-llm/config.yaml
+++ b/mistral/mistral-7b-trt-llm/config.yaml
@@ -1,6 +1,8 @@
 base_image:
   image: docker.io/baseten/triton_trt_llm:v2
   python_executable_path: /usr/bin/python3
+build:
+  model_server: TRT_LLM
 environment_variables: {}
 external_package_dirs: []
 model_metadata:
@@ -21,6 +23,7 @@ resources:
   accelerator: A100
   use_gpu: true
 secrets: {}
-system_packages: []
+system_packages:
+- python3.10-venv
 runtime:
   predict_concurrency: 256


### PR DESCRIPTION
- Adds model server build config to prevent development deployment of TRT-LLM servers, while we work on adding patching support to these examples