### PR TITLE
Revert "Add model server build config   (#78)"

### DIFF
--- a/llama/llama-2-7b-trt-llm/config.yaml
+++ b/llama/llama-2-7b-trt-llm/config.yaml
@@ -1,8 +1,6 @@
 base_image:
   image: nvcr.io/nvidia/tritonserver:23.10-trtllm-python-py3
   python_executable_path: /usr/bin/python3
-build:
-  model_server: TRT_LLM
 environment_variables: {}
 external_package_dirs: []
 model_metadata:

--- a/mistral/mistral-7b-trt-llm/config.yaml
+++ b/mistral/mistral-7b-trt-llm/config.yaml
@@ -1,8 +1,6 @@
 base_image:
   image: docker.io/baseten/triton_trt_llm:v2
   python_executable_path: /usr/bin/python3
-build:
-  model_server: TRT_LLM
 environment_variables: {}
 external_package_dirs: []
 model_metadata:


### PR DESCRIPTION
This reverts commit 5f5fcb52613ce0cd47d68669028aa211db348781. We should wait for https://github.com/basetenlabs/truss/pull/748 to be released to properly handle this config