### PR TITLE
Dont return full output

### DIFF
--- a/mistral/mistral-7b-chat/config.yaml
+++ b/mistral/mistral-7b-chat/config.yaml
@@ -14,6 +14,7 @@ requirements:
 - accelerate
 - transformers==4.34.0
 - torch==2.0.1
+- hf_transfer==0.1.4
 resources:
   accelerator: A10G
   use_gpu: true

--- a/mistral/mistral-7b-chat/config.yaml
+++ b/mistral/mistral-7b-chat/config.yaml
@@ -6,6 +6,7 @@ model_metadata:
   cover_image_url: https://cdn.baseten.co/production/static/explore/mistral.png
   tags:
   - text-generation
+  - openai-compatible
 model_name: Mistral 7B Chat
 python_version: py311
 requirements:

--- a/mistral/mistral-7b-chat/model/model.py
+++ b/mistral/mistral-7b-chat/model/model.py
@@ -35,7 +35,9 @@ class Model:
         }
 
         request["generate_args"] = {
-            k: request[k] if k in request else generate_args[k]
+            k: request[k]
+            if k in request and request[k] is not None
+            else generate_args[k]
             for k in generate_args.keys()
         }
 

--- a/mistral/mistral-7b-chat/model/model.py
+++ b/mistral/mistral-7b-chat/model/model.py
@@ -79,7 +79,10 @@ class Model:
             return self.stream(model_inputs, generation_args)
 
         with torch.no_grad():
-            try:
-                return self._model(text_inputs=model_inputs, **generation_args)
-            except Exception as exc:
-                return {"status": "error", "data": None, "message": str(exc)}
+
+            results = self._model(text_inputs=model_inputs, **generation_args)
+
+            if len(results) > 0:
+                return results[0].get("generated_text")
+
+            raise Exception("No results returned from model")

--- a/zephyr/zephyr-7b-alpha/config.yaml
+++ b/zephyr/zephyr-7b-alpha/config.yaml
@@ -14,6 +14,7 @@ requirements:
 - accelerate
 - transformers==4.34.0
 - torch==2.0.1
+- hf_transfer==0.1.4
 resources:
   accelerator: A10G
   use_gpu: true

--- a/zephyr/zephyr-7b-alpha/model/model.py
+++ b/zephyr/zephyr-7b-alpha/model/model.py
@@ -35,7 +35,9 @@ class Model:
         }
 
         request["generate_args"] = {
-            k: request[k] if k in request else generate_args[k]
+            k: request[k]
+            if k in request and request[k] is not None
+            else generate_args[k]
             for k in generate_args.keys()
         }
 

--- a/zephyr/zephyr-7b-alpha/model/model.py
+++ b/zephyr/zephyr-7b-alpha/model/model.py
@@ -79,7 +79,10 @@ class Model:
             return self.stream(model_inputs, generation_args)
 
         with torch.no_grad():
-            try:
-                return self._model(text_inputs=model_inputs, **generation_args)
-            except Exception as exc:
-                return {"status": "error", "data": None, "message": str(exc)}
+
+            results = self._model(text_inputs=model_inputs, **generation_args)
+
+            if len(results) > 0:
+                return results[0].get("generated_text")
+
+            raise Exception("No results returned from model")

--- a/zephyr/zephyr-7b-alpha/model/model.py
+++ b/zephyr/zephyr-7b-alpha/model/model.py
@@ -1,32 +1,22 @@
 from threading import Thread
 
 import torch
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    GenerationConfig,
-    TextIteratorStreamer,
-)
+from transformers import GenerationConfig, TextIteratorStreamer, pipeline
 
 CHECKPOINT = "HuggingFaceH4/zephyr-7b-alpha"
 
 
 class Model:
     def __init__(self, **kwargs):
-        self.tokenizer = None
-        self.model = None
+        self._model = None
 
     def load(self):
-        self.model = AutoModelForCausalLM.from_pretrained(
-            CHECKPOINT,
-            torch_dtype=torch.float16,
-            device_map="auto",
-        )
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            CHECKPOINT,
+        self._model = pipeline(
+            "text-generation",
+            model=CHECKPOINT,
+            torch_dtype=torch.bfloat16,
             device_map="auto",
-            torch_dtype=torch.float16,
         )
 
     def preprocess(self, request: dict):
@@ -39,8 +29,9 @@ class Model:
             "no_repeat_ngram_size": 0,
             "use_cache": True,
             "do_sample": True,
-            "eos_token_id": self.tokenizer.eos_token_id,
-            "pad_token_id": self.tokenizer.pad_token_id,
+            "eos_token_id": self._model.tokenizer.eos_token_id,
+            "pad_token_id": self._model.tokenizer.pad_token_id,
+            "return_full_text": False,
         }
 
         request["generate_args"] = {
@@ -50,11 +41,11 @@ class Model:
 
         return request
 
-    def stream(self, input_ids: list, generation_args: dict):
-        streamer = TextIteratorStreamer(self.tokenizer)
+    def stream(self, text_inputs: list, generation_args: dict):
+        streamer = TextIteratorStreamer(self._model.tokenizer)
         generation_config = GenerationConfig(**generation_args)
         generation_kwargs = {
-            "input_ids": input_ids,
+            "text_inputs": text_inputs,
             "generation_config": generation_config,
             "return_dict_in_generate": True,
             "output_scores": True,
@@ -64,7 +55,7 @@ class Model:
 
         with torch.no_grad():
             # Begin generation in a separate thread
-            thread = Thread(target=self.model.generate, kwargs=generation_kwargs)
+            thread = Thread(target=self._model, kwargs=generation_kwargs)
             thread.start()
 
             # Yield generated text as it becomes available
@@ -79,9 +70,9 @@ class Model:
         stream = request.pop("stream", False)
         messages = request.pop("messages")
 
-        model_inputs = self.tokenizer.apply_chat_template(
-            messages, return_tensors="pt"
-        ).cuda()
+        model_inputs = self._model.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
         generation_args = request.pop("generate_args")
 
         if stream:
@@ -89,7 +80,6 @@ class Model:
 
         with torch.no_grad():
             try:
-                output = self.model.generate(inputs=model_inputs, **generation_args)
-                return self.tokenizer.decode(output[0])
+                return self._model(text_inputs=model_inputs, **generation_args)
             except Exception as exc:
                 return {"status": "error", "data": None, "message": str(exc)}


### PR DESCRIPTION
# Summary

There was an issue with using zephyr & mistral with the openai clients where they were returning the full conversation. Fix that, along with another issue in which for zephyr, "null" value for max_tokens was resulting in no content being returned.

# Testing

Tested both of these agains the OpenAI clients.

## Mistral

```
$ poetry run python test.py

ChatCompletion(id='chatcmpl-91d33382-80ae-4948-90eb-9a5d12bf98d3', choices=[Choice(finish_reason=None, index=0, message=ChatCompletionMessage(content='The 2020 World Series was played at Globe Life Field in Arlington, Texas.', role='assistant', function_call=None, tool_calls=None))], created=1700610404, model='8w672xyq', object='chat.completion', system_fingerprint=None, usage=CompletionUsage(completion_tokens=0, prompt_tokens=0, total_tokens=0))
```

## Zephyr 

```
$ poetry run python test.py

ChatCompletion(id='chatcmpl-4bbb7f52-dab4-4a43-9bd3-26aab01bc16a', choices=[Choice(finish_reason=None, index=0, message=ChatCompletionMessage(content='<|assistant|>\nThe 2020 World Series was played in a neutral site due to the COVID-19 pandemic. The games were held at Arlington, Texas, at the Globe Life Field, which was the home stadium of the Texas Rangers.', role='assistant', function_call=None, tool_calls=None))], created=1700610441, model='rwnpdl13', object='chat.completion', system_fingerprint=None, usage=CompletionUsage(completion_tokens=0, prompt_tokens=0, total_tokens=0))
```
# Followups

Format out the "<|assistant" text that zephyr provides