### PR TITLE
Fix llama-2-13b-chat.

### DIFF
--- a/llama/llama-2-13b-chat/config.yaml
+++ b/llama/llama-2-13b-chat/config.yaml
@@ -24,6 +24,7 @@ requirements:
 - bitsandbytes==0.41.1
 - einops==0.6.1
 - faker==19.3.1
+- hf-transfer==0.1.4
 - peft==0.5.0
 - protobuf==3.20.3
 - safetensors==0.3.3


### PR DESCRIPTION
For some reason, this truss requires hf-transfer to be installed. Digging in further, but this is a stop-gap solution.