### PR TITLE
Set `enable_trt_overlap` to False

### DIFF
--- a/llama/llama-2-7b-trt-llm/TRT-LLM-README.md
+++ b/llama/llama-2-7b-trt-llm/TRT-LLM-README.md
@@ -73,7 +73,8 @@ parameters: {
   }
 }
 ```
-The `max_num_sequences` param is the maximum numbers of requests that the inference server can maintain state for at a given time (state = KV cache + decoder state). If this value is greater than your max batch size, we'll try to ping pong processing between max_num_sequences // max_batch_size batches. This assumes that `enable_trt_overlap` is set to `True` (as it is by default in this Truss). Setting this value higher allows for more parallel processing but uses more GPU memory.
+The `max_num_sequences` param is the maximum numbers of requests that the inference server can maintain state for at a given time (state = KV cache + decoder state).
+See this [comment](https://github.com/NVIDIA/TensorRT-LLM/issues/65#issuecomment-1774332446) for more details. Setting this value higher allows for more parallel processing but uses more GPU memory.
 
 ### API
 

--- a/llama/llama-2-7b-trt-llm/packages/inflight_batcher_llm/tensorrt_llm/config.pbtxt
+++ b/llama/llama-2-7b-trt-llm/packages/inflight_batcher_llm/tensorrt_llm/config.pbtxt
@@ -203,6 +203,6 @@ parameters: {
 parameters: {
   key: "enable_trt_overlap"
   value: {
-    string_value: "True"
+    string_value: "False"
   }
 }

--- a/mistral/mistral-7b-instruct-chat-trt-llm/TRT-LLM-README.md
+++ b/mistral/mistral-7b-instruct-chat-trt-llm/TRT-LLM-README.md
@@ -73,7 +73,8 @@ parameters: {
   }
 }
 ```
-The `max_num_sequences` param is the maximum numbers of requests that the inference server can maintain state for at a given time (state = KV cache + decoder state). If this value is greater than your max batch size, we'll try to ping pong processing between max_num_sequences // max_batch_size batches. This assumes that `enable_trt_overlap` is set to `True` (as it is by default in this Truss). Setting this value higher allows for more parallel processing but uses more GPU memory.
+The `max_num_sequences` param is the maximum numbers of requests that the inference server can maintain state for at a given time (state = KV cache + decoder state).
+See this [comment](https://github.com/NVIDIA/TensorRT-LLM/issues/65#issuecomment-1774332446) for more details. Setting this value higher allows for more parallel processing but uses more GPU memory.
 
 ### API
 

--- a/mistral/mistral-7b-instruct-chat-trt-llm/packages/inflight_batcher_llm/tensorrt_llm/config.pbtxt
+++ b/mistral/mistral-7b-instruct-chat-trt-llm/packages/inflight_batcher_llm/tensorrt_llm/config.pbtxt
@@ -203,6 +203,6 @@ parameters: {
 parameters: {
   key: "enable_trt_overlap"
   value: {
-    string_value: "True"
+    string_value: "False"
   }
 }

--- a/mistral/mistral-7b-trt-llm-build-engine/TRT-LLM-README.md
+++ b/mistral/mistral-7b-trt-llm-build-engine/TRT-LLM-README.md
@@ -73,7 +73,8 @@ parameters: {
   }
 }
 ```
-The `max_num_sequences` param is the maximum numbers of requests that the inference server can maintain state for at a given time (state = KV cache + decoder state). If this value is greater than your max batch size, we'll try to ping pong processing between max_num_sequences // max_batch_size batches. This assumes that `enable_trt_overlap` is set to `True` (as it is by default in this Truss). Setting this value higher allows for more parallel processing but uses more GPU memory.
+The `max_num_sequences` param is the maximum numbers of requests that the inference server can maintain state for at a given time (state = KV cache + decoder state).
+See this [comment](https://github.com/NVIDIA/TensorRT-LLM/issues/65#issuecomment-1774332446) for more details. Setting this value higher allows for more parallel processing but uses more GPU memory.
 
 ### API
 

--- a/mistral/mistral-7b-trt-llm-build-engine/packages/inflight_batcher_llm/tensorrt_llm/config.pbtxt
+++ b/mistral/mistral-7b-trt-llm-build-engine/packages/inflight_batcher_llm/tensorrt_llm/config.pbtxt
@@ -203,6 +203,6 @@ parameters: {
 parameters: {
   key: "enable_trt_overlap"
   value: {
-    string_value: "True"
+    string_value: "False"
   }
 }

--- a/templates/trt-llm/TRT-LLM-README.md
+++ b/templates/trt-llm/TRT-LLM-README.md
@@ -73,7 +73,8 @@ parameters: {
   }
 }
 ```
-The `max_num_sequences` param is the maximum numbers of requests that the inference server can maintain state for at a given time (state = KV cache + decoder state). If this value is greater than your max batch size, we'll try to ping pong processing between max_num_sequences // max_batch_size batches. This assumes that `enable_trt_overlap` is set to `True` (as it is by default in this Truss). Setting this value higher allows for more parallel processing but uses more GPU memory.
+The `max_num_sequences` param is the maximum numbers of requests that the inference server can maintain state for at a given time (state = KV cache + decoder state).
+See this [comment](https://github.com/NVIDIA/TensorRT-LLM/issues/65#issuecomment-1774332446) for more details. Setting this value higher allows for more parallel processing but uses more GPU memory.
 
 ### API
 

--- a/templates/trt-llm/packages/inflight_batcher_llm/tensorrt_llm/config.pbtxt
+++ b/templates/trt-llm/packages/inflight_batcher_llm/tensorrt_llm/config.pbtxt
@@ -203,6 +203,6 @@ parameters: {
 parameters: {
   key: "enable_trt_overlap"
   value: {
-    string_value: "True"
+    string_value: "False"
   }
 }


### PR DESCRIPTION
- We found in our benchmarking runs that setting this server config to `False` results in better throughput and latency for the majority of customer use cases we are trying to support, this PR makes the change to the templates these examples are generated from