### PR TITLE
Use tensor and pipeline parallelism equal to 1 in build engine truss

### DIFF
--- a/mistral/mistral-7b-trt-llm-build-engine/config.yaml
+++ b/mistral/mistral-7b-trt-llm-build-engine/config.yaml
@@ -10,7 +10,7 @@ model_metadata:
       64 --use_inflight_batching --max_input_len 2000 --max_output_len 2000 --paged_kv_cache
     cmd: examples/llama/build.py
   example_model_input: {"prompt": "What's the meaning of life?", "max_tokens": 1024}
-  pipeline_parallelism: 2
+  pipeline_parallelism: 1
   tags:
   - text-generation
   tensor_parallelism: 1
@@ -21,7 +21,7 @@ requirements:
 - tritonclient[all]
 - pynvml==11.5.0
 resources:
-  accelerator: A100:2
+  accelerator: A100
   use_gpu: true
 runtime:
   predict_concurrency: 256

--- a/templates/generate.yaml
+++ b/templates/generate.yaml
@@ -58,14 +58,15 @@ mistral/mistral-7b-trt-llm-build-engine:
       engine_build:
         cmd: examples/llama/build.py
         args: --remove_input_padding --use_gpt_attention_plugin float16 --enable_context_fmha --use_gemm_plugin float16 --max_batch_size 64 --use_inflight_batching --max_input_len 2000 --max_output_len 2000 --paged_kv_cache
-      pipeline_parallelism: 2
+      tensor_parallelism: 1
+      pipeline_parallelism: 1
     description: Generate text from a prompt with this seven billion parameter language model.
     model_name: Mistral 7B TRT
     requirements:
     - tritonclient[all]
     - pynvml==11.5.0
     resources:
-      accelerator: A100:2
+      accelerator: A100
   ignore:
     - README.md
     - model/model.py


### PR DESCRIPTION
It would be better to use simpler configuration for mistral trt with build engine config.