### PR TITLE
Fix replit transformers version

### DIFF
--- a/replit-code-1.3b/README.md
+++ b/replit-code-1.3b/README.md
@@ -74,18 +74,17 @@ increasing the `max_new_tokens` parameter to 200-300.
 
 
 ```sh
-truss predict -d '{"prompt": "def fib(n):", "do_sample": True, "max_new_tokens": 300}'
+truss predict -d '{"prompt": "def fib(n):", "do_sample": "True", "max_new_tokens": 300}'
 ```
 
 You can also invoke your model via a REST API
 
 ```
-curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
-     -H "Content-Type: application/json" \
-     -H 'Authorization: Api-Key {YOUR_API_KEY}' \
-     -d '{
-           "prompt": "def fib(n):",
-           "do_sample": True,
-           "max_new_tokens": 300,
-         }'
+curl -X POST https://model-<Your_Model_Id>.api.baseten.co/development/predict \
+  -H 'Authorization: Api-Key YOUR_API_KEY' \
+  -d '{
+        "prompt": "def fibonacci(n):",
+        "do_sample": "True",
+        "max_new_tokens": 300
+      }'
 ```

--- a/replit-code-1.3b/config.yaml
+++ b/replit-code-1.3b/config.yaml
@@ -11,7 +11,7 @@ model_class_filename: model.py
 model_class_name: Model
 model_framework: custom
 model_metadata:
-  example_model_input: {"prompt": "Write code for fibonacci"}
+  example_model_input: {"prompt": "Write code for fibonacci", "do_sample": "True", "max_new_tokens": 300}
   tags:
   - text-generation
 model_module_dir: model

--- a/replit-code-1.3b/config.yaml
+++ b/replit-code-1.3b/config.yaml
@@ -20,12 +20,12 @@ model_type: custom
 python_version: py39
 requirements:
 - torch
-- peft
 - sentencepiece
 - accelerate
 - bitsandbytes
 - einops
-- git+https://github.com/huggingface/transformers.git
+- transformers==4.33.0
+- scipy
 resources:
   cpu: "3"
   memory: 14Gi


### PR DESCRIPTION
The Replit Model architecture was broken with a HF Transformers library update (via the underlying MPT architecture):  [](https://huggingface.co/replit/replit-code-v1_5-3b/discussions/10) + [](https://huggingface.co/mosaicml/mpt-7b/discussions/83)
The Replit model doesn’t currently run as written. 
It also needed to have some other import changes to run.

I have specified a transformers version that works for this model, and tidy’ed up some of the readme and config, as they weren’t working for me for some of the commands with the new link structure. 

As a side note, there is a new Replit model that has been released. It doesn’t work on the most up-to-date version of transformers either, but I would expect that to get fixed/maintained better than this version + would likely show better performance.