### PR TITLE
Add blip Model for Image-Text (Captioning)

### DIFF
--- a/blip-image-captioning-large/README.md
+++ b/blip-image-captioning-large/README.md
@@ -2,7 +2,7 @@
 
 This repository packages [Blip Image Captioning Large](https://huggingface.co/Salesforce/blip-image-captioning-large) as a [Truss](https://truss.baseten.co).
 
-Replit Code 1.3B is an LLM released by Replit, optimized and trained for generating code autocompletions.
+Blip Image Captioning Large is a Image to Text model, specifically for generating image captions.
 
 ## Deploying Blip Image Captioning Large
 
@@ -70,7 +70,7 @@ truss predict -d '{"image_url": "https://storage.googleapis.com/sfr-vision-langu
 
 Or with the REST API
 
-curl -X POST https://model-<Your Model ID>.api.baseten.co/development/predict \
+curl -X POST https://model-<Your_Model_ID>.api.baseten.co/development/predict \
   -H 'Authorization: Api-Key YOUR_API_KEY' \
   -d '{"image_url": "https://storage.googleapis.com/sfr-vision-language-research/BLIP/demo.jpg", "text": "a photography of"}'
 
@@ -84,7 +84,7 @@ truss predict -d '{"image_url": "https://storage.googleapis.com/sfr-vision-langu
 
 Or with the REST API
 
-curl -X POST https://model-<Your Model ID>.api.baseten.co/development/predict \
+curl -X POST https://model-<Your_Model_ID>.api.baseten.co/development/predict \
   -H 'Authorization: Api-Key YOUR_API_KEY' \
   -d '{"image_url": "https://storage.googleapis.com/sfr-vision-language-research/BLIP/demo.jpg"}'
 

--- a/blip-image-captioning-large/README.md
+++ b/blip-image-captioning-large/README.md
@@ -1,0 +1,90 @@
+# Blip Image Captioning Large Truss
+
+This repository packages [Blip Image Captioning Large](https://huggingface.co/Salesforce/blip-image-captioning-large) as a [Truss](https://truss.baseten.co).
+
+Replit Code 1.3B is an LLM released by Replit, optimized and trained for generating code autocompletions.
+
+## Deploying Blip Image Captioning Large
+
+First, clone this repository:
+
+```sh
+git clone https://github.com/basetenlabs/truss-examples/
+cd  blip-image-captioning-large
+```
+
+Before deployment:
+
+1. Make sure you have a [Baseten account](https://app.baseten.co/signup) and [API key](https://app.baseten.co/settings/account/api_keys).
+2. Install the latest version of Truss: `pip install --upgrade truss`
+
+With `blip-image-captioning-large` as your working directory, you can deploy the model with:
+
+```sh
+truss push
+```
+
+Paste your Baseten API key if prompted.
+
+For more information, see [Truss documentation](https://truss.baseten.co).
+
+### Hardware notes
+
+We found this model runs reasonably fast on A10Gs; you can configure the hardware you'd like in the config.yaml.
+
+```yaml
+...
+resources:
+  cpu: "3"
+  memory: 14Gi
+  use_gpu: true
+  accelerator: A10G
+...
+```
+
+Before deployment:
+
+1. Make sure you have a Baseten account and API key. You can sign up for a Baseten account [here](https://app.baseten.co/signup).
+2. Install Truss and the Baseten Python client: `pip install --upgrade baseten truss`
+3. Authenticate your development environment with `baseten login`
+
+Deploying the Truss is easy; simply load it and push from a Python script:
+
+```python
+import baseten
+import truss
+
+blip_image_captioning_large_truss = truss.load('.')
+baseten.deploy(blip_image_captioning_large_truss)
+```
+
+## Invoking Blip Image Captioning Large
+
+You can either choose Conditional, or Unconditional Generation
+
+With Conditional Generation, you can set a prefix for the generated output, allowing guidance of the model:
+
+```sh
+truss predict -d '{"image_url": "https://storage.googleapis.com/sfr-vision-language-research/BLIP/demo.jpg", "text" : "a photography of"}'
+```
+
+Or with the REST API
+
+curl -X POST https://model-<Your Model ID>.api.baseten.co/development/predict \
+  -H 'Authorization: Api-Key YOUR_API_KEY' \
+  -d '{"image_url": "https://storage.googleapis.com/sfr-vision-language-research/BLIP/demo.jpg", "text": "a photography of"}'
+
+
+
+With Unconditional Generation, you let the model generate the full output on its own:
+
+```sh
+truss predict -d '{"image_url": "https://storage.googleapis.com/sfr-vision-language-research/BLIP/demo.jpg"}'
+```
+
+Or with the REST API
+
+curl -X POST https://model-<Your Model ID>.api.baseten.co/development/predict \
+  -H 'Authorization: Api-Key YOUR_API_KEY' \
+  -d '{"image_url": "https://storage.googleapis.com/sfr-vision-language-research/BLIP/demo.jpg"}'
+

--- a/blip-image-captioning-large/config.yaml
+++ b/blip-image-captioning-large/config.yaml
@@ -1,0 +1,25 @@
+environment_variables: {}
+external_package_dirs: []
+description: Model Serving for Salesforce/blip-image-captioning-large
+model_metadata:
+  example_model_input: {"image_url": "https://storage.googleapis.com/sfr-vision-language-research/BLIP/demo.jpg"}
+  tags:
+  - image-to-text
+model_name: blip-image-captioning-large
+model_class_filename: model.py
+model_class_name: Model
+model_framework: custom
+model_module_dir: model
+python_version: py39
+requirements: 
+- torch==2.0.1
+- transformers==4.33.1
+- Pillow
+- hf_transfer
+resources:
+  cpu: "3"
+  memory: 14Gi
+  use_gpu: true
+  accelerator: A10G
+secrets: {}
+system_packages: []

--- a/blip-image-captioning-large/model/model.py
+++ b/blip-image-captioning-large/model/model.py
@@ -1,0 +1,46 @@
+from typing import Dict
+
+import torch
+from transformers import BlipProcessor, BlipForConditionalGeneration
+from transformers import AutoProcessor
+import requests
+from PIL import Image
+
+
+CHECKPOINT = "Salesforce/blip-image-captioning-large"
+
+class Model:
+    def __init__(self, data_dir: str, config: Dict, **kwargs) -> None:
+        self._data_dir = data_dir
+        self._config = config
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.processor = None
+        self.model = None
+
+    def load(self):
+        self.processor = AutoProcessor.from_pretrained(CHECKPOINT)
+        self.model = BlipForConditionalGeneration.from_pretrained("Salesforce/blip-image-captioning-large").to(self.device)
+        
+    def predict(self, request: Dict) -> Dict:
+        try:
+            img_url = request["image_url"]
+            raw_image = Image.open(requests.get(img_url, stream=True).raw).convert('RGB')
+            with torch.no_grad():
+                inputs = None
+                if "text" in request:
+                    #Conditional generation
+                    text = request["text"]
+                    inputs = self.processor(raw_image, text, return_tensors="pt").to(self.device)
+
+                else:
+                    #Unconditional generation
+                    inputs = self.processor(raw_image, return_tensors="pt").to(self.device)
+
+                outputs = self.model.generate(**inputs)
+
+                caption = self.processor.decode(outputs[0], skip_special_tokens=True)
+
+                return {"data" : caption}
+
+        except Exception as exc:
+                return {"status": "error", "data": None, "message": str(exc)}


### PR DESCRIPTION
I saw that there weren’t any image-text models in the examples. This is one for [BLIP-Large](https://huggingface.co/Salesforce/blip-image-captioning-large). 

It includes README + support for conditional and unconditional Caption Generation for images.
