### PR TITLE
Fix examples CI

### DIFF
--- a/ci.yaml
+++ b/ci.yaml
@@ -15,5 +15,4 @@ tests:
   - gfp-gan
   - zephyr/zephyr-7b-alpha
   - stable-diffusion/stable-diffusion-xl-1.0
-  - pygmalion-6b
   - whisper/faster-whisper-truss

--- a/ci.yaml
+++ b/ci.yaml
@@ -15,6 +15,5 @@ tests:
   - gfp-gan
   - zephyr/zephyr-7b-alpha
   - stable-diffusion/stable-diffusion-xl-1.0
-  - deepspeed-mii
   - pygmalion-6b
   - whisper/faster-whisper-truss

--- a/whisper/faster-whisper-truss/config.yaml
+++ b/whisper/faster-whisper-truss/config.yaml
@@ -1,5 +1,8 @@
 environment_variables: {}
 external_package_dirs: []
+base_image:
+  image: baseten/truss-server-base:3.10-gpu-v0.4.9
+  python_executable_path: /usr/bin/python3
 model_name: Faster Whisper
 python_version: py39
 model_metadata:


### PR DESCRIPTION
Makes the following changes:
* Remove deepspeed-mii from the CI (it needs an A100, which we just don't have here)
* Fix the faster-whisper truss (I tried pushing it myself, and it worked)
* Add exponential backoff around `truss.push`