### PR TITLE
Use randomly generated uuid

### DIFF
--- a/llama/llama-2-7b-trt-llm/model/model.py
+++ b/llama/llama-2-7b-trt-llm/model/model.py
@@ -1,3 +1,4 @@
+import uuid
 from itertools import count
 from pathlib import Path
 from threading import Thread
@@ -6,7 +7,6 @@ import numpy as np
 from client import TritonClient, UserData
 from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
-import uuid
 
 TRITON_MODEL_REPOSITORY_PATH = Path("/packages/inflight_batcher_llm/")
 
@@ -68,7 +68,7 @@ class Model:
     def predict(self, model_input):
         user_data = UserData()
         model_name = "ensemble"
-        stream_uuid = str(uuid.uuid4().int & (1<<32)-1)
+        stream_uuid = str(uuid.uuid4().int & (1 << 32) - 1)
 
         if self.uses_openai_api:
             prompt = self.tokenizer.apply_chat_template(

--- a/llama/llama-2-7b-trt-llm/model/model.py
+++ b/llama/llama-2-7b-trt-llm/model/model.py
@@ -6,6 +6,7 @@ import numpy as np
 from client import TritonClient, UserData
 from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
+import uuid
 
 TRITON_MODEL_REPOSITORY_PATH = Path("/packages/inflight_batcher_llm/")
 
@@ -67,7 +68,7 @@ class Model:
     def predict(self, model_input):
         user_data = UserData()
         model_name = "ensemble"
-        stream_uuid = str(next(self._request_id_counter))
+        stream_uuid = str(uuid.uuid4().int & (1<<32)-1)
 
         if self.uses_openai_api:
             prompt = self.tokenizer.apply_chat_template(

--- a/mistral/mistral-7b-instruct-chat-trt-llm/model/model.py
+++ b/mistral/mistral-7b-instruct-chat-trt-llm/model/model.py
@@ -1,3 +1,4 @@
+import uuid
 from itertools import count
 from pathlib import Path
 from threading import Thread
@@ -6,7 +7,6 @@ import numpy as np
 from client import TritonClient, UserData
 from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
-import uuid
 
 TRITON_MODEL_REPOSITORY_PATH = Path("/packages/inflight_batcher_llm/")
 
@@ -68,7 +68,7 @@ class Model:
     def predict(self, model_input):
         user_data = UserData()
         model_name = "ensemble"
-        stream_uuid = str(uuid.uuid4().int & (1<<32)-1)
+        stream_uuid = str(uuid.uuid4().int & (1 << 32) - 1)
 
         if self.uses_openai_api:
             prompt = self.tokenizer.apply_chat_template(

--- a/mistral/mistral-7b-instruct-chat-trt-llm/model/model.py
+++ b/mistral/mistral-7b-instruct-chat-trt-llm/model/model.py
@@ -6,6 +6,7 @@ import numpy as np
 from client import TritonClient, UserData
 from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
+import uuid
 
 TRITON_MODEL_REPOSITORY_PATH = Path("/packages/inflight_batcher_llm/")
 
@@ -67,7 +68,7 @@ class Model:
     def predict(self, model_input):
         user_data = UserData()
         model_name = "ensemble"
-        stream_uuid = str(next(self._request_id_counter))
+        stream_uuid = str(uuid.uuid4().int & (1<<32)-1)
 
         if self.uses_openai_api:
             prompt = self.tokenizer.apply_chat_template(

--- a/templates/trt-llm/model/model.py
+++ b/templates/trt-llm/model/model.py
@@ -1,3 +1,4 @@
+import uuid
 from itertools import count
 from pathlib import Path
 from threading import Thread
@@ -6,7 +7,6 @@ import numpy as np
 from client import TritonClient, UserData
 from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
-import uuid
 
 TRITON_MODEL_REPOSITORY_PATH = Path("/packages/inflight_batcher_llm/")
 
@@ -68,7 +68,7 @@ class Model:
     def predict(self, model_input):
         user_data = UserData()
         model_name = "ensemble"
-        stream_uuid = str(uuid.uuid4().int & (1<<32)-1)
+        stream_uuid = str(uuid.uuid4().int & (1 << 32) - 1)
 
         if self.uses_openai_api:
             prompt = self.tokenizer.apply_chat_template(

--- a/templates/trt-llm/model/model.py
+++ b/templates/trt-llm/model/model.py
@@ -6,6 +6,7 @@ import numpy as np
 from client import TritonClient, UserData
 from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
+import uuid
 
 TRITON_MODEL_REPOSITORY_PATH = Path("/packages/inflight_batcher_llm/")
 
@@ -67,7 +68,7 @@ class Model:
     def predict(self, model_input):
         user_data = UserData()
         model_name = "ensemble"
-        stream_uuid = str(next(self._request_id_counter))
+        stream_uuid = str(uuid.uuid4().int & (1<<32)-1)
 
         if self.uses_openai_api:
             prompt = self.tokenizer.apply_chat_template(


### PR DESCRIPTION
The id is 32 bit random which is not good in general, but should unblock benchmarking with multiple workers. I had difficulties passing longer ids to trtllm, so that needs some work. Perhaps we can combine worker id with auto-increment id, will explore  in follow up.