### PR TITLE
Make mistral trt llm engine build model to use mistral instruct model

### DIFF
--- a/mistral/mistral-7b-trt-llm-build-engine/README.md
+++ b/mistral/mistral-7b-trt-llm-build-engine/README.md
@@ -2,7 +2,7 @@
 
 # Mistral-7B Truss
 
-This is a [Truss](https://truss.baseten.co/) for Mistral 7B. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Mistral 7B.
+This is a [Truss](https://truss.baseten.co/) for Mistral 7B Instruct v0.2. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Mistral 7B Instruct v0.2.
 
 This truss differs from `mistral-7b-trt-llm` by supporting building trt-llm engines on the fly on the model load.
 This significantly increases model start time and therefore it's **not intended for production use**.
@@ -12,7 +12,7 @@ To make use of this feature, specify both the build command in `model_metadata.e
 
 Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten. Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy on Baseten.
 
-## Deploying Mistral-7B
+## Deploying Mistral 7B Instruct v0.2
 
 First, clone this repository:
 
@@ -41,10 +41,14 @@ This section provides an overview of the Mistral 7B API, its parameters, and how
 
 ### API route: `predict`
 
+This model is designed for our ChatCompletions endpoint:
+
+- [ChatCompletions endpoint tutorial](https://www.baseten.co/blog/gpt-vs-mistral-migrate-to-open-source-llms-with-minor-code-changes/)
+- [ChatCompletions endpoint reference docs](https://docs.baseten.co/api-reference/openai)
+
 We expect requests will the following information:
 
-
-- ```prompt``` (str): The prompt you'd like to complete
+- ```messages``` (str): The prompt you'd like to complete
 - ```max_tokens``` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
 - ```beam_width``` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
 - ```bad_words_list``` (list, default:[]): A list of words to not include in generated output.
@@ -52,21 +56,3 @@ We expect requests will the following information:
 - ```repetition_penalty``` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
 
 This Truss will stream responses back. Responses will be buffered chunks of text.
-
-## Example usage
-
-```sh
-truss predict -d '{"prompt": "What is the meaning of life?"}'
-```
-
-You can also invoke your model via a REST API
-
-```sh
-curl -X POST " https://app.baseten.co/models/YOUR_MODEL_ID/predict" \
-     -H "Content-Type: application/json" \
-     -H 'Authorization: Api-Key {YOUR_API_KEY}' \
-     -d '{
-           "prompt": "What's the meaning of life?",
-         }'
-
-```

--- a/mistral/mistral-7b-trt-llm-build-engine/config.yaml
+++ b/mistral/mistral-7b-trt-llm-build-engine/config.yaml
@@ -9,13 +9,14 @@ model_metadata:
     args: --remove_input_padding --use_gpt_attention_plugin float16 --enable_context_fmha --use_gemm_plugin float16 --max_batch_size
       64 --use_inflight_batching --max_input_len 2000 --max_output_len 2000 --paged_kv_cache
     cmd: examples/llama/build.py
-  example_model_input: {"prompt": "What's the meaning of life?", "max_tokens": 1024}
+  example_model_input: {"messages": [{"role": "user", "content": "What is the mistral wind?"}]}
   pipeline_parallelism: 1
   tags:
   - text-generation
+  - openai-compatible
   tensor_parallelism: 1
-  tokenizer_repository: mistralai/Mistral-7B-v0.1
-model_name: Mistral 7B TRT
+  tokenizer_repository: mistralai/Mistral-7B-Instruct-v0.2
+model_name: Mistral 7B Instrcut v0.2 TRT
 python_version: py311
 requirements:
 - tritonclient[all]

--- a/mistral/mistral-7b-trt-llm-build-engine/config.yaml
+++ b/mistral/mistral-7b-trt-llm-build-engine/config.yaml
@@ -21,6 +21,7 @@ python_version: py311
 requirements:
 - tritonclient[all]
 - pynvml==11.5.0
+- transformers==4.34.0
 resources:
   accelerator: A100
   use_gpu: true

--- a/mistral/mistral-7b-trt-llm-build-engine/config.yaml
+++ b/mistral/mistral-7b-trt-llm-build-engine/config.yaml
@@ -16,7 +16,7 @@ model_metadata:
   - openai-compatible
   tensor_parallelism: 1
   tokenizer_repository: mistralai/Mistral-7B-Instruct-v0.2
-model_name: Mistral 7B Instrcut v0.2 TRT
+model_name: Mistral 7B Instruct v0.2 TRT
 python_version: py311
 requirements:
 - tritonclient[all]

--- a/mistral/mistral-7b-trt-llm-build-engine/model/model.py
+++ b/mistral/mistral-7b-trt-llm-build-engine/model/model.py
@@ -1,9 +1,9 @@
+import os
 from itertools import count
 from pathlib import Path
 from threading import Thread
 
 import numpy as np
-from build_engine_utils import BuildConfig, build_engine
 from client import TritonClient, UserData
 from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
@@ -18,10 +18,16 @@ class Model:
         self._secrets = kwargs["secrets"]
         self._request_id_counter = count(start=1)
         self.triton_client = None
+        self.tokenizer = None
+        self.uses_openai_api = (
+            "openai-compatible" in self._config["model_metadata"]["tags"]
+        )
 
     def load(self):
-        tensor_parallelism = self._config["model_metadata"].get("tensor_parallelism", 1)
-        pipeline_parallelism = self._config["model_metadata"].get(
+        tensor_parallel_count = self._config["model_metadata"].get(
+            "tensor_parallelism", 1
+        )
+        pipeline_parallel_count = self._config["model_metadata"].get(
             "pipeline_parallelism", 1
         )
         if "hf_access_token" in self._secrets._base_secrets.keys():
@@ -29,13 +35,12 @@ class Model:
         else:
             hf_access_token = None
         is_external_engine_repo = "engine_repository" in self._config["model_metadata"]
-        tokenizer_repository = self._config["model_metadata"]["tokenizer_repository"]
 
         # Instantiate TritonClient
         self.triton_client = TritonClient(
             data_dir=self._data_dir,
             model_repository_dir=TRITON_MODEL_REPOSITORY_PATH,
-            parallel_count=tensor_parallelism * pipeline_parallelism,
+            parallel_count=tensor_parallel_count * pipeline_parallel_count,
         )
 
         # Download model from Hugging Face Hub if specified
@@ -45,24 +50,9 @@ class Model:
                 fp=self._data_dir,
                 auth_token=hf_access_token,
             )
-        if "engine_build" in self._config["model_metadata"]:
-            if not is_external_engine_repo:
-                build_engine(
-                    model_repo=tokenizer_repository,
-                    config=BuildConfig(
-                        **self._config["model_metadata"]["engine_build"]
-                    ),
-                    dst=self._data_dir,
-                    hf_auth_token=hf_access_token,
-                    tensor_parallelism=tensor_parallelism,
-                    pipeline_parallelism=pipeline_parallelism,
-                )
-            else:
-                raise Exception(
-                    "`engine_build` and `engine_repository` can't be specified at the same time"
-                )
 
         # Load Triton Server and model
+        tokenizer_repository = self._config["model_metadata"]["tokenizer_repository"]
         env = {"triton_tokenizer_repository": tokenizer_repository}
         if hf_access_token is not None:
             env["HUGGING_FACE_HUB_TOKEN"] = hf_access_token
@@ -70,17 +60,24 @@ class Model:
         self.triton_client.load_server_and_model(env=env)
 
         # setup eos token
-        tokenizer = AutoTokenizer.from_pretrained(
+        self.tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_repository, token=hf_access_token
         )
-        self.eos_token_id = tokenizer.eos_token_id
+        self.eos_token_id = self.tokenizer.eos_token_id
 
     def predict(self, model_input):
         user_data = UserData()
         model_name = "ensemble"
-        stream_uuid = str(next(self._request_id_counter))
+        stream_uuid = str(os.getpid()) + str(next(self._request_id_counter))
 
-        prompt = model_input.get("prompt")
+        if self.uses_openai_api:
+            prompt = self.tokenizer.apply_chat_template(
+                model_input.get("messages"),
+                tokenize=False,
+            )
+        else:
+            prompt = model_input.get("prompt")
+
         max_tokens = model_input.get("max_tokens", 50)
         beam_width = model_input.get("beam_width", 1)
         bad_words_list = model_input.get("bad_words_list", [""])
@@ -133,4 +130,7 @@ class Model:
         if stream:
             return generate()
         else:
-            return {"text": "".join(generate())}
+            if self.uses_openai_api:
+                return "".join(generate())
+            else:
+                return {"text": "".join(generate())}

--- a/mistral/mistral-7b-trt-llm-build-engine/model/model.py
+++ b/mistral/mistral-7b-trt-llm-build-engine/model/model.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from threading import Thread
 
 import numpy as np
+from build_engine_utils import BuildConfig, build_engine
 from client import TritonClient, UserData
 from transformers import AutoTokenizer
 from utils import download_engine, prepare_grpc_tensor
@@ -50,9 +51,25 @@ class Model:
                 fp=self._data_dir,
                 auth_token=hf_access_token,
             )
+        tokenizer_repository = self._config["model_metadata"]["tokenizer_repository"]
+        if "engine_build" in self._config["model_metadata"]:
+            if not is_external_engine_repo:
+                build_engine(
+                    model_repo=tokenizer_repository,
+                    config=BuildConfig(
+                        **self._config["model_metadata"]["engine_build"]
+                    ),
+                    dst=self._data_dir,
+                    hf_auth_token=hf_access_token,
+                    tensor_parallelism=tensor_parallel_count,
+                    pipeline_parallelism=pipeline_parallel_count,
+                )
+            else:
+                raise Exception(
+                    "`engine_build` and `engine_repository` can't be specified at the same time"
+                )
 
         # Load Triton Server and model
-        tokenizer_repository = self._config["model_metadata"]["tokenizer_repository"]
         env = {"triton_tokenizer_repository": tokenizer_repository}
         if hf_access_token is not None:
             env["HUGGING_FACE_HUB_TOKEN"] = hf_access_token

--- a/templates/generate.yaml
+++ b/templates/generate.yaml
@@ -64,7 +64,7 @@ mistral/mistral-7b-trt-llm-build-engine:
       - text-generation
       - openai-compatible
     description: Generate text from a prompt with this seven billion parameter language model.
-    model_name: Mistral 7B Instrcut v0.2 TRT
+    model_name: Mistral 7B Instruct v0.2 TRT
     requirements:
     - tritonclient[all]
     - pynvml==11.5.0

--- a/templates/generate.yaml
+++ b/templates/generate.yaml
@@ -51,17 +51,20 @@ mistral/mistral-7b-trt-llm-build-engine:
     base_image:
       image: docker.io/baseten/triton_trt_llm:v2
     model_metadata:
-      example_model_input: {"prompt": "What's the meaning of life?", "max_tokens": 1024}
+      example_model_input: {"messages": [{"role": "user", "content": "What is the mistral wind?"}]}
       avatar_url: https://cdn.baseten.co/production/static/explore/mistral_logo.png
       cover_image_url: https://cdn.baseten.co/production/static/explore/mistral.png
-      tokenizer_repository: "mistralai/Mistral-7B-v0.1"
+      tokenizer_repository: "mistralai/Mistral-7B-Instruct-v0.2"
       engine_build:
         cmd: examples/llama/build.py
         args: --remove_input_padding --use_gpt_attention_plugin float16 --enable_context_fmha --use_gemm_plugin float16 --max_batch_size 64 --use_inflight_batching --max_input_len 2000 --max_output_len 2000 --paged_kv_cache
       tensor_parallelism: 1
       pipeline_parallelism: 1
+      tags:
+      - text-generation
+      - openai-compatible
     description: Generate text from a prompt with this seven billion parameter language model.
-    model_name: Mistral 7B TRT
+    model_name: Mistral 7B Instrcut v0.2 TRT
     requirements:
     - tritonclient[all]
     - pynvml==11.5.0

--- a/templates/generate.yaml
+++ b/templates/generate.yaml
@@ -68,6 +68,7 @@ mistral/mistral-7b-trt-llm-build-engine:
     requirements:
     - tritonclient[all]
     - pynvml==11.5.0
+    - transformers==4.34.0
     resources:
       accelerator: A100
   ignore:


### PR DESCRIPTION
Instruct model is much easier / better to interact with, and supports chat inputs. I've changed out `mistral-7B-trt-llm` model to use Mistral 7B instruct v0.2.