### PR TITLE
Remove all deploy buttons

### DIFF
--- a/alpaca-7b/README.md
+++ b/alpaca-7b/README.md
@@ -1,8 +1,7 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/alpaca)
-
 # Alpaca-7B Truss
 
 This is a [Truss](https://truss.baseten.co/) for Alpaca-7B, a fine-tuned variant of LLaMA-7B. LLaMA is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Alpaca-7B.
+
 ## Deploy Alpaca-7B
 
 First, clone this repository:
@@ -28,16 +27,18 @@ Paste your Baseten API key if prompted.
 For more information, see [Truss documentation](https://truss.baseten.co).
 
 ## Alpaca-7B API documentation
-This section provides an overview of the Alpaca-7B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+
+This section provides an overview of the Alpaca-7B API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate text based on the provided instruction.
 
 ### API route: `predict`
+
 The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __instruction__: The input text that you want the model to generate a response for.
-- __temperature__ (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
-- __top_p__ (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
-- __top_k__ (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
-- __num_beams__ (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
+- **instruction**: The input text that you want the model to generate a response for.
+- **temperature** (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
+- **top_p** (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
+- **top_k** (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
+- **num_beams** (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
 
 The API also supports passing any parameter supported by Huggingface's `Transformers.generate`.
 

--- a/deepfloyd-xl/README.md
+++ b/deepfloyd-xl/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/deepfloyd)
-
 # DeepFloyd XL Truss
 
 This is a [Truss](https://truss.baseten.co/) for DeepFloyd-IF. DeepFloyd-IF is a pixel-based text-to-image triple-cascaded diffusion model that can generate pictures and sets a new state-of-the-art for photorealism and language understanding. The result is a highly efficient model that outperforms current state-of-the-art models, achieving a zero-shot FID-30K score of 6.66 on the COCO dataset.
@@ -50,7 +48,7 @@ For more information, see [Truss documentation](https://truss.baseten.co).
 
 This deployment of DeepFloyd takes a dictionary as input, which requires the following key:
 
-* `prompt` - the prompt for image generation
+- `prompt` - the prompt for image generation
 
 It also supports a number of other parameters detailed in [this blog post](https://huggingface.co/blog/if).
 
@@ -58,12 +56,16 @@ It also supports a number of other parameters detailed in [this blog post](https
 
 The result will be a dictionary containing:
 
-* `status` - either `success` or `failed`
-* `data` - list of base 64 encoded images
-* `message` - will contain details in the case of errors
+- `status` - either `success` or `failed`
+- `data` - list of base 64 encoded images
+- `message` - will contain details in the case of errors
 
 ```json
-{"status": "success", "data": ["/9j/4AAQSkZJRgABAQAAAQABAA...."], "message": null}
+{
+  "status": "success",
+  "data": ["/9j/4AAQSkZJRgABAQAAAQABAA...."],
+  "message": null
+}
 ```
 
 ## Example usage

--- a/flan-t5-xl/README.md
+++ b/flan-t5-xl/README.md
@@ -1,16 +1,14 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/flan_t5)
-
 # FLAN-T5 XL Truss
 
 [Flan-T5 XL](https://huggingface.co/google/flan-t5-xl?text=Q%3A+%28+False+or+not+False+or+False+%29+is%3F+A%3A+Let%27s+think+step+by+step) is an open-source large language model developed by Google.
 
 Flan-T5 XL has a number of use cases such as:
 
-* Sentiment analysis
-* Paraphrasing/sentence similarity
-* Natural language inference
-* Sentence completion
-* Question answering
+- Sentiment analysis
+- Paraphrasing/sentence similarity
+- Natural language inference
+- Sentence completion
+- Question answering
 
 Flan-T5 XL is similar to T5 except it is "instruction tuned". In practice, this means that the model is comparable to GPT-3 in multitask benchmarks because it is fine-tuned to follow human inputs / instructions.
 
@@ -37,14 +35,15 @@ truss push
 Paste your Baseten API key if prompted.
 
 For more information, see [Truss documentation](https://truss.baseten.co).
+
 ## FLAN-T5 XL API documentation
 
 ### Input
 
 The input should be a list of dictionaries and may contain the following key:
 
-* `prompt` - the prompt for text generation
-* `bad_words` - an optional list of strings to avoid in the generated output
+- `prompt` - the prompt for text generation
+- `bad_words` - an optional list of strings to avoid in the generated output
 
 The [official documentation](https://huggingface.co/docs/transformers/main/en/main_classes/text_generation#transformers.generation_utils.GenerationMixin.generate) has information on additional parameters.
 
@@ -59,9 +58,9 @@ The [official documentation](https://huggingface.co/docs/transformers/main/en/ma
 
 The result will be a dictionary containing:
 
-* `status` - either `success` or `failed`
-* `data` - the output text
-* `message` - will contain details in the case of errors
+- `status` - either `success` or `failed`
+- `data` - the output text
+- `message` - will contain details in the case of errors
 
 ```
 {

--- a/gfp-gan/README.md
+++ b/gfp-gan/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/gfp_gan)
-
 # GFP-GAN Truss
 
 This is a [Truss](https://truss.baseten.co/) for serving an implementation of TencentARC
@@ -38,15 +36,16 @@ For more information, see [Truss documentation](https://truss.baseten.co).
 ### Input
 
 The input should be a dictionary with the following key:
-* `image` - the image to be restored, encoded as base64.
+
+- `image` - the image to be restored, encoded as base64.
 
 ### Output
 
 The model returns a dictionary containing the base64-encoded restored image:
-* `status` - either `success` or `failed`
-* `data` - the restored image, encoded as base64
-* `message` - will contain details in the case of errors
 
+- `status` - either `success` or `failed`
+- `data` - the restored image, encoded as base64
+- `message` - will contain details in the case of errors
 
 ## Example usage
 

--- a/gpt-j/README.md
+++ b/gpt-j/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/gpt_j)
-
 # GPT-J Truss
 
 This is an implementation of EleutherAI
@@ -38,33 +36,33 @@ For more information, see [Truss documentation](https://truss.baseten.co).
 
 The input should be a list of dictionaries and must contain the following key:
 
-* `prompt` - the prompt for text generation
+- `prompt` - the prompt for text generation
 
 Additionally; the following optional parameters are supported as pass thru to the `generate` method. For more details, see the [official documentation](https://huggingface.co/docs/transformers/main/en/main_classes/text_generation#transformers.generation_utils.GenerationMixin.generate)
 
-* `max_length` - int - limited to  512
-* `min_length` - int - limited to 64
-* `do_sample` - bool
-* `early_stopping` - bool
-* `num_beams` - int
-* `temperature`  - float
-* `top_k` - int
-* `top_p` - float
-* `repetition_penalty` - float
-* `length_penalty` - float
-* `encoder_no_repeat_ngram_size` - int
-* `num_return_sequences` - int
-* `max_time` - float
-* `num_beam_groups` - int
-* `diversity_penalty` - float
-* `remove_invalid_values` - bool
+- `max_length` - int - limited to 512
+- `min_length` - int - limited to 64
+- `do_sample` - bool
+- `early_stopping` - bool
+- `num_beams` - int
+- `temperature` - float
+- `top_k` - int
+- `top_p` - float
+- `repetition_penalty` - float
+- `length_penalty` - float
+- `encoder_no_repeat_ngram_size` - int
+- `num_return_sequences` - int
+- `max_time` - float
+- `num_beam_groups` - int
+- `diversity_penalty` - float
+- `remove_invalid_values` - bool
 
 Here's an example input:
 
 ```json
 {
-    "prompt": "If I was a billionaire, I would",
-    "max_length": 50
+  "prompt": "If I was a billionaire, I would",
+  "max_length": 50
 }
 ```
 
@@ -72,12 +70,16 @@ Here's an example input:
 
 The result will be a dictionary containing:
 
-* `status` - either `success` or `failed`
-* `data` - the output text
-* `message` - will contain details in the case of errors
+- `status` - either `success` or `failed`
+- `data` - the output text
+- `message` - will contain details in the case of errors
 
 ```json
-{"status": "success", "data": "If I was a billionaire, I would buy a plane.", "message": null}
+{
+  "status": "success",
+  "data": "If I was a billionaire, I would buy a plane.",
+  "message": null
+}
 ```
 
 ## Example usage

--- a/llama/llama-2-7b-trt-llm/README.md
+++ b/llama/llama-2-7b-trt-llm/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/llama)
-
 # LLaMA2-7B-Chat Truss
 
 This is a [Truss](https://truss.baseten.co/) for an int8 SmoothQuant version of LLaMA2-7B-Chat. Llama is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of LLaMA2-7B-Chat.
@@ -35,19 +33,19 @@ Paste your Baseten API key if prompted.
 For more information, see [Truss documentation](https://truss.baseten.co).
 
 ## LLaMA2-7B API documentation
-This section provides an overview of the LLaMA2-7B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+
+This section provides an overview of the LLaMA2-7B API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate text based on the provided instruction.
 
 ### API route: `predict`
 
 We expect requests will the following information:
 
-
-- ```prompt``` (str): The prompt you'd like to complete
-- ```max_tokens``` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
-- ```beam_width``` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
-- ```bad_words_list``` (list, default:[]): A list of words to not include in generated output.
-- ```stop_words_list``` (list, default:[]): A list of words to stop generation upon encountering.
-- ```repetition_penalty``` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
+- `prompt` (str): The prompt you'd like to complete
+- `max_tokens` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
+- `beam_width` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
+- `bad_words_list` (list, default:[]): A list of words to not include in generated output.
+- `stop_words_list` (list, default:[]): A list of words to stop generation upon encountering.
+- `repetition_penalty` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
 
 This Truss will stream responses back. Responses will be buffered chunks of text.
 

--- a/llama/llama-7b/README.md
+++ b/llama/llama-7b/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/llama)
-
 # LLaMA-7B Truss
 
 This is a [Truss](https://truss.baseten.co/) for an int8 version of LLaMA-7B. Llama is a family of language models released by Meta. This README will walk you through how to deploy this Truss on Baseten to get your own instance of LLaMA-7B.
@@ -33,16 +31,18 @@ Paste your Baseten API key if prompted.
 For more information, see [Truss documentation](https://truss.baseten.co).
 
 ## LLaMA-7B API documentation
-This section provides an overview of the LLaMA-7B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+
+This section provides an overview of the LLaMA-7B API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate text based on the provided instruction.
 
 ### API route: `predict`
+
 The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __instruction__: The input text that you want the model to generate a response for.
-- __temperature__ (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
-- __top_p__ (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
-- __top_k__ (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
-- __num_beams__ (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
+- **instruction**: The input text that you want the model to generate a response for.
+- **temperature** (optional, default=0.1): Controls the randomness of the generated text. Higher values produce more diverse results, while lower values produce more deterministic results.
+- **top_p** (optional, default=0.75): The cumulative probability threshold for token sampling. The model will only consider tokens whose cumulative probability is below this threshold.
+- **top_k** (optional, default=40): The number of top tokens to consider when sampling. The model will only consider the top_k highest-probability tokens.
+- **num_beams** (optional, default=4): The number of beams used for beam search. Increasing this value can result in higher-quality output but will increase the computational cost.
 
 The API also supports passing any parameter supported by Huggingface's `Transformers.generate`.
 

--- a/mistral/mistral-7b-instruct-chat-trt-llm-smooth-quant/README.md
+++ b/mistral/mistral-7b-instruct-chat-trt-llm-smooth-quant/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/mistral)
-
 # Mistral-7B-Instruct-Chat Truss
 
 This is a [Truss](https://truss.baseten.co/) for Mistral 7B Instruct. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Mistral 7B Instruct.
@@ -35,7 +33,8 @@ Paste your Baseten API key if prompted.
 For more information, see [Truss documentation](https://truss.baseten.co).
 
 ## Mistral 7B Instruct API documentation
-This section provides an overview of the Mistral 7B Instruct API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+
+This section provides an overview of the Mistral 7B Instruct API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate text based on the provided instruction.
 
 ### API route: `predict`
 
@@ -46,11 +45,11 @@ This model is designed for our ChatCompletions endpoint:
 
 We expect requests will the following information:
 
-- ```messages``` (str): The prompt you'd like to complete
-- ```max_tokens``` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
-- ```beam_width``` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
-- ```bad_words_list``` (list, default:[]): A list of words to not include in generated output.
-- ```stop_words_list``` (list, default:[]): A list of words to stop generation upon encountering.
-- ```repetition_penalty``` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
+- `messages` (str): The prompt you'd like to complete
+- `max_tokens` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
+- `beam_width` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
+- `bad_words_list` (list, default:[]): A list of words to not include in generated output.
+- `stop_words_list` (list, default:[]): A list of words to stop generation upon encountering.
+- `repetition_penalty` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
 
 This Truss will stream responses back. Responses will be buffered chunks of text.

--- a/mistral/mistral-7b-instruct-chat-trt-llm-weights-only-quant/README.md
+++ b/mistral/mistral-7b-instruct-chat-trt-llm-weights-only-quant/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/mistral)
-
 # Mistral-7B-Instruct-Chat Truss
 
 This is a [Truss](https://truss.baseten.co/) for Mistral 7B Instruct. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Mistral 7B Instruct.
@@ -35,7 +33,8 @@ Paste your Baseten API key if prompted.
 For more information, see [Truss documentation](https://truss.baseten.co).
 
 ## Mistral 7B Instruct API documentation
-This section provides an overview of the Mistral 7B Instruct API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+
+This section provides an overview of the Mistral 7B Instruct API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate text based on the provided instruction.
 
 ### API route: `predict`
 
@@ -46,11 +45,11 @@ This model is designed for our ChatCompletions endpoint:
 
 We expect requests will the following information:
 
-- ```messages``` (str): The prompt you'd like to complete
-- ```max_tokens``` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
-- ```beam_width``` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
-- ```bad_words_list``` (list, default:[]): A list of words to not include in generated output.
-- ```stop_words_list``` (list, default:[]): A list of words to stop generation upon encountering.
-- ```repetition_penalty``` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
+- `messages` (str): The prompt you'd like to complete
+- `max_tokens` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
+- `beam_width` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
+- `bad_words_list` (list, default:[]): A list of words to not include in generated output.
+- `stop_words_list` (list, default:[]): A list of words to stop generation upon encountering.
+- `repetition_penalty` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
 
 This Truss will stream responses back. Responses will be buffered chunks of text.

--- a/mistral/mistral-7b-instruct-chat-trt-llm/README.md
+++ b/mistral/mistral-7b-instruct-chat-trt-llm/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/mistral)
-
 # Mistral-7B-Instruct-Chat Truss
 
 This is a [Truss](https://truss.baseten.co/) for Mistral 7B Instruct. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Mistral 7B Instruct.
@@ -35,7 +33,8 @@ Paste your Baseten API key if prompted.
 For more information, see [Truss documentation](https://truss.baseten.co).
 
 ## Mistral 7B Instruct API documentation
-This section provides an overview of the Mistral 7B Instruct API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+
+This section provides an overview of the Mistral 7B Instruct API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate text based on the provided instruction.
 
 ### API route: `predict`
 
@@ -46,11 +45,11 @@ This model is designed for our ChatCompletions endpoint:
 
 We expect requests will the following information:
 
-- ```messages``` (str): The prompt you'd like to complete
-- ```max_tokens``` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
-- ```beam_width``` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
-- ```bad_words_list``` (list, default:[]): A list of words to not include in generated output.
-- ```stop_words_list``` (list, default:[]): A list of words to stop generation upon encountering.
-- ```repetition_penalty``` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
+- `messages` (str): The prompt you'd like to complete
+- `max_tokens` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
+- `beam_width` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
+- `bad_words_list` (list, default:[]): A list of words to not include in generated output.
+- `stop_words_list` (list, default:[]): A list of words to stop generation upon encountering.
+- `repetition_penalty` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
 
 This Truss will stream responses back. Responses will be buffered chunks of text.

--- a/mistral/mistral-7b-trt-llm-build-engine/README.md
+++ b/mistral/mistral-7b-trt-llm-build-engine/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/mistral)
-
 # Mistral-7B Truss
 
 This is a [Truss](https://truss.baseten.co/) for Mistral 7B Instruct v0.2. This README will walk you through how to deploy this Truss on Baseten to get your own instance of Mistral 7B Instruct v0.2.
@@ -37,7 +35,8 @@ Paste your Baseten API key if prompted.
 For more information, see [Truss documentation](https://truss.baseten.co).
 
 ## Mistral 7B API documentation
-This section provides an overview of the Mistral 7B API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+
+This section provides an overview of the Mistral 7B API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate text based on the provided instruction.
 
 ### API route: `predict`
 
@@ -48,11 +47,11 @@ This model is designed for our ChatCompletions endpoint:
 
 We expect requests will the following information:
 
-- ```messages``` (str): The prompt you'd like to complete
-- ```max_tokens``` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
-- ```beam_width``` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
-- ```bad_words_list``` (list, default:[]): A list of words to not include in generated output.
-- ```stop_words_list``` (list, default:[]): A list of words to stop generation upon encountering.
-- ```repetition_penalty``` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
+- `messages` (str): The prompt you'd like to complete
+- `max_tokens` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
+- `beam_width` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
+- `bad_words_list` (list, default:[]): A list of words to not include in generated output.
+- `stop_words_list` (list, default:[]): A list of words to stop generation upon encountering.
+- `repetition_penalty` (float, defualt: 1.0): A repetition penalty to incentivize not repeating tokens.
 
 This Truss will stream responses back. Responses will be buffered chunks of text.

--- a/nsql/README.md
+++ b/nsql/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/nsql)
-
 # NSQL Truss
 
 This is a [Truss](https://truss.baseten.co/) for [Number Station](https://www.numbersstation.ai/)'s 350M parameter NSQL model. NSQL is a text-to-SQL foundation model, enabling users to query their databases using natual language. There are also 2B and 6B NSQL variants available, which you can alternatively deploy by editing the HuggingFace paths in `model/model.py`.
@@ -35,17 +33,20 @@ Paste your Baseten API key if prompted.
 For more information, see [Truss documentation](https://truss.baseten.co).
 
 ## NSQL API documentation
-This section provides an overview of the NSQL API, its parameters, and how to use it. The API consists of a single route named  `predict`, which you can invoke to generate text based on the provided instruction.
+
+This section provides an overview of the NSQL API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate text based on the provided instruction.
 
 ### API route: `predict`
+
 The predict route is the primary method for generating text completions based on a given instruction. It takes several parameters:
 
-- __schema__: An SQL schema for the table you want to query. You can provide multiple schemas as a single string.
-- __query__: A natural language query over the provided database schemas.
+- **schema**: An SQL schema for the table you want to query. You can provide multiple schemas as a single string.
+- **query**: A natural language query over the provided database schemas.
 
 ## Example usage
 
 You can use the `baseten` model package to invoke your model from Python
+
 ```
 import baseten
 # You can retrieve your deployed model ID from the UI

--- a/stable-diffusion/stable-diffusion/README.md
+++ b/stable-diffusion/stable-diffusion/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/stable_diffusion)
-
 # Stable Diffusion Truss
 
 This is a [Truss](https://truss.baseten.co/) for Stable Diffusion v2.1 using the `StableDiffusionPipeline` from the `diffusers` library. This README will walk you through how to deploy this Truss on Baseten to get your own instance of the Stable Diffusion.
@@ -69,16 +67,17 @@ curl -X POST "https://app.baseten.co/models/MODEL_ID/predict" \
 
 Again, the model will return a dictionary containing the base64-encoded image, which will need to be decoded and saved.
 
-
 ### Stable Diffusion API documentation
+
 This section provides an overview of the Stable Diffusion API, its parameters, and how to use it. The API consists of a single route named `predict`, which you can invoke to generate images based on the provided parameters.
 
 #### API route: `predict`
+
 The predict route is the primary method for generating images based on a given set of parameters. It takes several parameters:
 
-- __prompt__: The input text you'd like to generate an image for
-- __scheduler__: (optional, default: DDIM) The scheduler used for the diffusion process. Choose from: "ddim", "dpm", "euler", "lms", or "pndm".
-- __seed__: (optional) A random seed for deterministic results. If not provided, a random seed will be generated.
-- __negative_prompt__: (optional) A string representing the negative prompt, or prompts that indicate what you don't want to generate.
+- **prompt**: The input text you'd like to generate an image for
+- **scheduler**: (optional, default: DDIM) The scheduler used for the diffusion process. Choose from: "ddim", "dpm", "euler", "lms", or "pndm".
+- **seed**: (optional) A random seed for deterministic results. If not provided, a random seed will be generated.
+- **negative_prompt**: (optional) A string representing the negative prompt, or prompts that indicate what you don't want to generate.
 
 The API also supports passing any parameter supported by Diffuser's `StableDiffusionPipeline`.

--- a/stablelm/README.md
+++ b/stablelm/README.md
@@ -1,5 +1,3 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/stablelm)
-
 # StableLM Truss
 
 This repository packages [StableLM](https://github.com/Stability-AI/StableLM) as a [Truss](https://truss.baseten.co).
@@ -11,35 +9,37 @@ Stability AI recently announced the ongoing development of the StableLM series o
 Utilizing these models for inference can be challenging given the hardware requirements. With Baseten and Truss, this can be dead simple. You can see the full code repository here.
 
 There are four models that were released:
-* "stabilityai/stablelm-base-alpha-7b"
-* "stabilityai/stablelm-tuned-alpha-7b"
-* "stabilityai/stablelm-base-alpha-3b"
-* "stabilityai/stablelm-tuned-alpha-3b"
+
+- "stabilityai/stablelm-base-alpha-7b"
+- "stabilityai/stablelm-tuned-alpha-7b"
+- "stabilityai/stablelm-base-alpha-3b"
+- "stabilityai/stablelm-tuned-alpha-3b"
 
 You can modify the `load` method in `model.py` to select the version you'd like to deploy.
 
-``` python
+```python
 model_name = "stabilityai/stablelm-tuned-alpha-7b" #@param ["stabilityai/stablelm-base-alpha-7b", "stabilityai/stablelm-tuned-alpha-7b", "stabilityai/stablelm-base-alpha-3b", "stabilityai/stablelm-tuned-alpha-3b"]
 ```
 
 We found this model runs reasonably fast on A10Gs; you can configure the hardware you'd like in the `config.yaml`.
 
 ```yaml
-...
+
+---
 resources:
   cpu: "3"
   memory: 14Gi
   use_gpu: true
   accelerator: A10G
-...
 ```
+
 The usual GPT-style parameters will pass right through to the inference point:
 
-* max_new_tokens (_default_: 64)
-* temperature (_default_: 0.5)
-* top_p (_default_: 0.9)
-* top_k (_default_: 0)
-* num_beams (_default_: 4)
+- max*new_tokens (\_default*: 64)
+- temperature (_default_: 0.5)
+- top*p (\_default*: 0.9)
+- top*k (\_default*: 0)
+- num*beams (\_default*: 4)
 
 If the tuned versions are needed for use in Chatbots; prepend the input message with the system prompt as described in the StableLM Readme:
 

--- a/whisper/whisper-truss/README.md
+++ b/whisper/whisper-truss/README.md
@@ -1,15 +1,13 @@
-[![Deploy to Baseten](https://user-images.githubusercontent.com/2389286/236301770-16f46d4f-4e23-4db5-9462-f578ec31e751.svg)](https://app.baseten.co/explore/whisper)
-
 # Whisper Truss
 
 [Whisper](https://github.com/openai/whisper) is a speech-to-text model by [OpenAI](https://openai.com/blog/whisper/) that transcribes audio in dozens of languages with remarkable accuracy. It is open-source under the [MIT license](https://github.com/openai/whisper/blob/main/LICENSE) and hosted on Baseten as a pre-trained model. Read the [Whisper model card](https://github.com/openai/whisper/blob/main/model-card.md) for more details.
 
 Whisper's leap in transcription quality unlocks tons of compelling use cases, including:
 
-* Moderating audio content
-* Auditing call center logs
-* Automatically generating video subtitles
-* Improving podcast SEO with transcripts
+- Moderating audio content
+- Auditing call center logs
+- Automatically generating video subtitles
+- Improving podcast SEO with transcripts
 
 ## Deploying Whisper
 
@@ -53,7 +51,7 @@ This deployment of Whisper takes input as a JSON dictionary with the key `url` c
 
 ```json
 {
-    "url": "https://cdn.baseten.co/docs/production/Gettysburg.mp3"
+  "url": "https://cdn.baseten.co/docs/production/Gettysburg.mp3"
 }
 ```
 
@@ -63,19 +61,19 @@ The model returns a fairly lengthy dictionary. For most uses, you'll be interest
 
 ```json
 {
-    "language": "english",
-    "segments": [
-        {
-        "start": 0,
-        "end": 6.5200000000000005,
-        "text": " Four score and seven years ago, our fathers brought forth upon this continent a new nation"
-        },
-        {
-        "start": 6.52,
-        "end": 21.6,
-        "text": " conceived in liberty and dedicated to the proposition that all men are created equal."
-        }
-    ],
-    "text": " Four score and seven years ago, our fathers brought forth upon this continent..."
+  "language": "english",
+  "segments": [
+    {
+      "start": 0,
+      "end": 6.5200000000000005,
+      "text": " Four score and seven years ago, our fathers brought forth upon this continent a new nation"
+    },
+    {
+      "start": 6.52,
+      "end": 21.6,
+      "text": " conceived in liberty and dedicated to the proposition that all men are created equal."
+    }
+  ],
+  "text": " Four score and seven years ago, our fathers brought forth upon this continent..."
 }
 ```


### PR DESCRIPTION
This PR removes all the `Deploy` buttons from model READMEs. These will likely return in some form after we transition to the new model library but until then lets remove them so the links aren't broken for each of these models. 