### PR TITLE
Add repo_id to llama repos

### DIFF
--- a/llama/llama-2-13b-chat/config.yaml
+++ b/llama/llama-2-13b-chat/config.yaml
@@ -13,6 +13,7 @@ model_metadata:
   example_model_input: {"prompt": "What's the meaning of life?", "temperature": 0.1, "top_p": 0.75,"num_beams": 4}
   avatar_url: https://cdn.baseten.co/production/static/explore/meta.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png
+  repo_id: meta-llama/Llama-2-13b-chat-hf
   tags:
   - text-generation
 model_module_dir: model

--- a/llama/llama-2-13b/config.yaml
+++ b/llama/llama-2-13b/config.yaml
@@ -10,7 +10,8 @@ live_reload: false
 model_class_filename: model.py
 model_class_name: Model
 model_framework: custom
-model_metadata: {}
+model_metadata:
+  repo_id: meta-llama/Llama-2-13b-hf
 model_module_dir: model
 model_name: Llama 13B
 model_type: custom

--- a/llama/llama-2-70b-chat/config.yaml
+++ b/llama/llama-2-70b-chat/config.yaml
@@ -13,6 +13,7 @@ model_metadata:
   example_model_input: {"prompt": "What's the meaning of life?", "temperature": 0.1, "top_p": 0.75,"num_beams": 4}
   avatar_url: https://cdn.baseten.co/production/static/explore/meta.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png
+  repo_id: meta-llama/Llama-2-70b-chat-hf
   tags:
   - text-generation
 model_module_dir: model

--- a/llama/llama-2-70b/config.yaml
+++ b/llama/llama-2-70b/config.yaml
@@ -10,7 +10,8 @@ live_reload: false
 model_class_filename: model.py
 model_class_name: Model
 model_framework: custom
-model_metadata: {}
+model_metadata:
+  repo_id: meta-llama/Llama-2-70b-hf
 model_module_dir: model
 model_name: Llama 70B
 model_type: custom

--- a/llama/llama-2-7b-chat-tgi/config.yaml
+++ b/llama/llama-2-7b-chat-tgi/config.yaml
@@ -4,7 +4,8 @@ build:
   model_server: TGI
 environment_variables: {}
 external_package_dirs: []
-model_metadata: {}
+model_metadata:
+  repo_id: meta-llama/Llama-2-7b-chat-hf
 model_name: Llama 7B Chat TGI
 python_version: py311
 requirements: []

--- a/llama/llama-2-7b-chat/config.yaml
+++ b/llama/llama-2-7b-chat/config.yaml
@@ -13,6 +13,7 @@ model_metadata:
   example_model_input: {"prompt": "What's the meaning of life?", "temperature": 0.1, "top_p": 0.75,"num_beams": 4}
   avatar_url: https://cdn.baseten.co/production/static/explore/meta.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png
+  repo_id: meta-llama/Llama-2-7b-chat-hf
   tags:
   - text-generation
 model_module_dir: model

--- a/llama/llama-2-7b-trt-llm/config.yaml
+++ b/llama/llama-2-7b-trt-llm/config.yaml
@@ -7,6 +7,7 @@ model_metadata:
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png
   engine_repository: baseten/llama_7b_sq0.8_4096ctx_64bs
   example_model_input: {"prompt": "What's the meaning of life?", "max_tokens": 1024}
+  repo_id: NousResearch/Llama-2-7b-chat-hf
   tags:
   - text-generation
   tensor_parallelism: 1

--- a/llama/llama-2-7b/config.yaml
+++ b/llama/llama-2-7b/config.yaml
@@ -10,7 +10,8 @@ live_reload: false
 model_class_filename: model.py
 model_class_name: Model
 model_framework: custom
-model_metadata: {}
+model_metadata:
+  repo_id: "meta-llama/Llama-2-7b-hf"
 model_module_dir: model
 model_name: Falcon 7B
 model_type: custom

--- a/templates/generate.yaml
+++ b/templates/generate.yaml
@@ -174,6 +174,7 @@ llama/llama-2-7b-trt-llm:
       cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png
       engine_repository: "baseten/llama_7b_sq0.8_4096ctx_64bs"
       tokenizer_repository: "NousResearch/Llama-2-7b-chat-hf"
+      repo_id: "NousResearch/Llama-2-7b-chat-hf"
     description: Generate text from a prompt with this seven billion parameter language model.
     model_name: Llama 7B Chat TRT
   ignore:


### PR DESCRIPTION
# Summary

In https://github.com/basetenlabs/baseten/pull/7807 & some previous PRs, we added some validation logic to check on baseten when deploying a model whether the user has access to the repo in question or not (with their access token). In order to do this check, we need to have the repo_id that the model is pointing to in Huggingface in the config (it has to be in some sort of structured data to read it).

In this PR, we add the correct repo_id to each of the  llama repos so we can validate them.

# Follow-up

A good follow-up to this would be reading the config value in the model.py files instead of hard-coding them there.