### PR TITLE
add model cache to sdxl trt example

### DIFF
--- a/stable-diffusion/stable-diffusion-xl-1.0-trt/config.yaml
+++ b/stable-diffusion/stable-diffusion-xl-1.0-trt/config.yaml
@@ -15,6 +15,8 @@ model_metadata:
 model_name: Stable Diffusion XL - TensorRT
 model_framework: custom
 model_type: custom
+model_cache:
+- repo_id: "baseten/sdxl-1.0-trt-8.6.1.post1-engine"
 python_version: py39
 system_packages:
 - python3.10-venv


### PR DESCRIPTION
- This change introduces the caching of engine plan files to improve cold starts for this model