### PR TITLE
Actually use secret in jina embeddings

### DIFF
--- a/jina-embeddings/jina-embeddings-v2-base-en/config.yaml
+++ b/jina-embeddings/jina-embeddings-v2-base-en/config.yaml
@@ -12,7 +12,7 @@ model_framework: custom
 model_name: Jina Embeddings V2 Base EN
 python_version: py39
 requirements:
-- transformers==4.34.1
+- transformers==4.37.2
 - torch==2.0.1
 resources:
   accelerator: null

--- a/jina-embeddings/jina-embeddings-v2-base-en/model/model.py
+++ b/jina-embeddings/jina-embeddings-v2-base-en/model/model.py
@@ -3,6 +3,7 @@ from transformers import AutoModel
 
 class Model:
     def __init__(self, **kwargs):
+        self.hf_access_token = kwargs["secrets"]["hf_access_token"]
         self._model = None
 
     def load(self):
@@ -10,6 +11,7 @@ class Model:
             "jinaai/jina-embeddings-v2-base-en",
             revision="0f472a4cde0e6e50067b8259a3a74d1110f4f8d8",
             trust_remote_code=True,
+            use_auth_token=self.hf_access_token,
         )  # Version is pinned to prevent malicious code execution
 
     def predict(self, model_input):

--- a/jina-embeddings/jina-embeddings-v2-base-en/model/model.py
+++ b/jina-embeddings/jina-embeddings-v2-base-en/model/model.py
@@ -1,18 +1,23 @@
+import os
+
 from transformers import AutoModel
 
 
 class Model:
     def __init__(self, **kwargs):
         self.hf_access_token = kwargs["secrets"]["hf_access_token"]
+        # There seems to be a bug where transfomers doesn't
+        # respect the "token" argument, but this environment
+        # variable works.
+        os.environ["HF_TOKEN"] = self.hf_access_token
         self._model = None
 
     def load(self):
         self._model = AutoModel.from_pretrained(
             "jinaai/jina-embeddings-v2-base-en",
-            revision="0f472a4cde0e6e50067b8259a3a74d1110f4f8d8",
             trust_remote_code=True,
-            use_auth_token=self.hf_access_token,
-        )  # Version is pinned to prevent malicious code execution
+            token=self.hf_access_token,
+        )
 
     def predict(self, model_input):
         if "max_length" not in model_input.keys():


### PR DESCRIPTION
Follow-up from https://github.com/basetenlabs/truss-examples/pull/179, actually make use of the secret.

There's a bug in the latest version transformers where the `token` parameter is not respected, which is why I had to do the weird environment variable thing.

# Testing

Tested by doing `truss push --trusted` in the repo, and ensuring that it deploys on my account.


