### PR TITLE
Pin torchvision for gfp-gan

### DIFF
--- a/gfp-gan/config.yaml
+++ b/gfp-gan/config.yaml
@@ -12,6 +12,7 @@ requirements:
 - gfpgan==1.3.8
 - realesrgan==0.3.0
 - basicsr==1.4.2
+- torchvision==0.16.2
 resources:
   cpu: "3"
   memory: 8Gi


### PR DESCRIPTION
# Context

While i was testing an unrelated change (truss types), the gfp-gan truss started failing in CI examples. After retrying a few times, it looked it like it was an issue with the latest version of torchvision (https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13985).

Because we were not pinning torchvision, we were getting this later version, that does not seem to be compatible with gfp-gan.

The quick fix here is pinning torchvision, although I will acknowledge that this is not sustainable, at some point we will need to update gfp-gan library. This at least gets us back to passing CI.

# Testing

Tested by deploying gfp-gan on staging, it worked successfully.