### PR TITLE
Github action for deploying new library models.

### DIFF
--- a/.github/workflows/deploy-library-model.yml
+++ b/.github/workflows/deploy-library-model.yml
@@ -1,0 +1,58 @@
+name: Deploy Library Model
+
+on:
+  schedule:
+    # Runs daily at 6am UTC
+    - cron:  '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      diff:
+        type: string
+
+jobs:
+  detect_changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11.4'
+      - name: Install dependencies (if any)
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/basetenlabs/truss.git requests tenacity --upgrade
+      - name: Run the detect changes script
+        run: |
+          LIBRARY_MODELS_TO_DEPLOY=python ./bin/detect_library_changes.py
+          echo "library_models_to_deploy=$LIBRARY_MODELS_TO_DEPLOY" >> $GITHUB_ENV
+          echo "library_models_to_deploy=$LIBRARY_MODELS_TO_DEPLOY" >> $GITHUB_OUTPUT
+
+        env:
+          DIFF: ${{ github.event.inputs.diff  || 'default_value' }}
+
+  deploy:
+    needs: detect_changes
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        library_model_to_deploy: ${{ fromJSON(needs.detect_changes.outputs.library_models_to_deploy) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11.4'
+      - name: Install dependencies (if any)
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/basetenlabs/truss.git requests pyyaml tenacity --upgrade
+      - name: Test => (${{ matrix.library_model_to_deploy }}
+        run: |
+          python ./bin/test_example.py ${{secrets.BASETEN_API_KEY}} ${{matrix.library_model_to_deploy}}
+      - name: Deploy => (${{ matrix.library_model_to_deploy }} to staging
+        run: |
+          echo "Deploying ${{ matrix.library_model_to_deploy}} to staging"
+          python ./bin/upsert_library_model.py ${{secrets.UPSERT_LIBRARY_MODELS_STAGING_API_KEY}} ${{matrix.library_model_to_deploy}} $GITHUB_SHA https://app.staging.baseten.co

--- a/.github/workflows/deploy-library-model.yml
+++ b/.github/workflows/deploy-library-model.yml
@@ -1,9 +1,9 @@
 name: Deploy Library Model
 
 on:
-  schedule:
-    # Runs daily at 6am UTC
-    - cron:  '0 6 * * *'
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       diff:

--- a/bin/detect_library_changes.py
+++ b/bin/detect_library_changes.py
@@ -1,0 +1,34 @@
+import json
+import subprocess
+import sys
+
+import yaml
+
+
+def compute_library_models_to_deploy(git_diff_arg):
+    command = ["git", "--no-pager", "diff", "--name-only", git_diff_arg]
+    git_diff_output = subprocess.run(
+        command, capture_output=True, text=True
+    ).stdout.strip()
+
+    files_changed = git_diff_output.split("\n")
+
+    with open("library.config.yaml", "r") as f:
+        library_contents = f.read()
+        library_models = yaml.safe_load(library_contents)
+
+    library_models_to_deploy = set()
+    for library_model_slug, library_model in library_models.items():
+        for file_changed in files_changed:
+            if file_changed.startswith(library_model["path"]):
+                library_models_to_deploy.add(library_model_slug)
+
+    return library_models_to_deploy
+
+
+if __name__ == "__main__":
+    git_diff_arg = sys.argv[1]
+
+    library_models_to_deploy = compute_library_models_to_deploy(git_diff_arg)
+
+    print(json.dumps(list(library_models_to_deploy)))

--- a/bin/upsert_library_model.py
+++ b/bin/upsert_library_model.py
@@ -1,0 +1,36 @@
+import json
+import sys
+
+import requests
+import yaml
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+
+@retry(wait=wait_fixed(20), stop=stop_after_attempt(3), reraise=True)
+def upsert_pretrained_model(api_key, model_slug, commit_sha, baseten_url):
+    url = f"{baseten_url}/upsert_pretrained_model"
+    headers = {"Authorization": f"Api-Key {api_key}"}
+    with open("library.config.yaml", "r") as f:
+        library_contents = f.read()
+        library_models = yaml.safe_load(library_contents)
+
+    model_to_deploy = library_models[model_slug]
+
+    data = {
+        "name": model_to_deploy["name"],
+        "slug": model_slug,
+        "repo_url": "https://github.com/basetenlabs/truss-examples",
+        "sha": commit_sha,
+        "path": model_to_deploy["path"],
+    }
+
+    requests.post(url, headers=headers, json=data)
+
+
+if __name__ == "__main__":
+    api_key = sys.argv[1]
+    model_to_deploy = sys.argv[2]
+    commit_sha = sys.argv[3]
+    baseten_url = sys.argv[4]
+
+    upsert_pretrained_model(api_key, model_to_deploy, commit_sha, baseten_url)

--- a/library.config.yaml
+++ b/library.config.yaml
@@ -1,0 +1,7 @@
+# TODO: Fill this out
+stable_diffusion:
+  name: Stable Diffusion
+  path: "stable-diffusion/stable-diffusion"
+qwen-vl:
+  name: "Quen VL"
+  path: "qwen/qwen-vl"


### PR DESCRIPTION
# Summary

Adds a github action that runs on merges to main that looks at what files have changed. If any of these files match any of the paths in the model library, then, upsert the new library model.

# Testing

[TODO] 

I added a way to trigger this workflow with a custom git diff string. For instance, if you trigger this with: "e7a81ae..0c78c6f", it will use that as the diff. This makes it easier to test.

Before merging this PR, I'll try triggering this workflow using the GH CLI.

# Follow-ups

- Add command to push models to production