### PR TITLE
Update typo in model.py "top_p" -> "top_k"

### DIFF
--- a/02-llm/model/model.py
+++ b/02-llm/model/model.py
@@ -46,7 +46,7 @@ class Model:
             "max_new_tokens": request.get("max_new_tokens", 128),
             "temperature": request.get("temperature", 1.0),
             "top_p": request.get("top_p", 0.95),
-            "top_k": request.get("top_p", 50),
+            "top_k": request.get("top_k", 50),
             "repetition_penalty": 1.0,
             "no_repeat_ngram_size": 0,
             "use_cache": True,


### PR DESCRIPTION
There appears to be a typo when setting the parameters for Mistral inference. top_k is being set using the top_p entry in the request dict