### PR TITLE
Fix mistral models to have an hf_access_token.

### DIFF
--- a/mistral/mistral-7b-chat/config.yaml
+++ b/mistral/mistral-7b-chat/config.yaml
@@ -31,5 +31,6 @@ resources:
   accelerator: A10G
   memory: 25Gi
   use_gpu: true
-secrets: {}
+secrets:
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 system_packages: []

--- a/mistral/mistral-7b-instruct/config.yaml
+++ b/mistral/mistral-7b-instruct/config.yaml
@@ -26,5 +26,6 @@ resources:
   accelerator: A10G
   memory: 10Gi
   use_gpu: true
-secrets: {}
+secrets:
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 system_packages: []


### PR DESCRIPTION
See https://basetenlabs.slack.com/archives/C052AKXNGES/p1713559863206319 for context, but right now our mistral models in the library will fail unless they have an hf access token.

These are the two that need the hf access token added.

This will change the model library to prompt users to have an hf access token added.