### PR TITLE
Actually use the auth tokens when pulling hf repos

### DIFF
--- a/mistral/mistral-7b-chat/model/model.py
+++ b/mistral/mistral-7b-chat/model/model.py
@@ -1,3 +1,4 @@
+import os
 from threading import Thread
 
 import torch
@@ -7,6 +8,7 @@ from transformers import GenerationConfig, TextIteratorStreamer, pipeline
 class Model:
     def __init__(self, **kwargs):
         self._repo_id = kwargs["config"]["model_metadata"]["model"]
+        self._hf_access_token = kwargs["secrets"]["hf_access_token"]
         self._model = None
 
     def load(self):
@@ -15,6 +17,7 @@ class Model:
             model=self._repo_id,
             torch_dtype=torch.bfloat16,
             device_map="auto",
+            token=self._hf_access_token,
         )
 
     def preprocess(self, request: dict):

--- a/mistral/mistral-7b-instruct/model/model.py
+++ b/mistral/mistral-7b-instruct/model/model.py
@@ -14,18 +14,21 @@ class Model:
         self.tokenizer = None
         self.model = None
         self._config = kwargs["config"]
+        self._hf_access_token = kwargs["secrets"]["hf_access_token"]
 
     def load(self):
         self.model = AutoModelForCausalLM.from_pretrained(
             self._config["model_cache"][0]["repo_id"],
             torch_dtype=torch.float16,
             device_map="auto",
+            token=self._hf_access_token,
         )
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             self._config["model_cache"][0]["repo_id"],
             device_map="auto",
             torch_dtype=torch.float16,
+            token=self._hf_access_token,
         )
 
     def preprocess(self, request: dict):


### PR DESCRIPTION
# Summary 

Follow-up from: https://github.com/basetenlabs/truss-examples/pull/275, actually needed to change the model code also.

# Testing

Deployed on my local account after accepting the terms for these mistral models.