### PR TITLE
Fix truss ci examples

### DIFF
--- a/02-llm/config.yaml
+++ b/02-llm/config.yaml
@@ -19,7 +19,8 @@ requirements:
 resources:
   accelerator: A10G
   use_gpu: true
-secrets: {}
+secrets:
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 system_packages: []
 # # Deploy the model
 #

--- a/02-llm/model/model.py
+++ b/02-llm/model/model.py
@@ -21,14 +21,19 @@ class Model:
     def __init__(self, **kwargs) -> None:
         self.tokenizer = None
         self.model = None
+        self._hf_access_token = kwargs["secrets"]["hf_access_token"]
 
     def load(self):
         self.model = AutoModelForCausalLM.from_pretrained(
-            CHECKPOINT, torch_dtype=torch.float16, device_map="auto"
+            CHECKPOINT,
+            torch_dtype=torch.float16,
+            device_map="auto",
+            token=self._hf_access_token,
         )
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             CHECKPOINT,
+            token=self._hf_access_token,
         )
 
     # # Define the `predict` function

--- a/mistral/mistral-7b/config.yaml
+++ b/mistral/mistral-7b/config.yaml
@@ -19,5 +19,6 @@ resources:
   accelerator: A10G
   memory: 25Gi
   use_gpu: true
-secrets: {}
+secrets:
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 system_packages: []

--- a/mistral/mistral-7b/model/model.py
+++ b/mistral/mistral-7b/model/model.py
@@ -15,16 +15,21 @@ class Model:
     def __init__(self, **kwargs):
         self.tokenizer = None
         self.model = None
+        self._hf_access_token = kwargs["secrets"]["hf_access_token"]
 
     def load(self):
         self.model = AutoModelForCausalLM.from_pretrained(
-            "mistralai/Mistral-7B-v0.1", torch_dtype=torch.float16, device_map="auto"
+            "mistralai/Mistral-7B-v0.1",
+            torch_dtype=torch.float16,
+            device_map="auto",
+            token=self._hf_access_token,
         )
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             "mistralai/Mistral-7B-v0.1",
             device_map="auto",
             torch_dtype=torch.float16,
+            token=self._hf_access_token,
         )
 
     def preprocess(self, request: dict):


### PR DESCRIPTION
Fix these to get the CI examples unblocked. For the 02-llm example, this is not ideal anymore, but we can fix the docs later. I still think mistral or llama would be the best examples to use there, even though they both require hf access token now.