### PR TITLE
Fix mistral trt example.

### DIFF
--- a/mistral/mistral-7b-chat/config.yaml
+++ b/mistral/mistral-7b-chat/config.yaml
@@ -15,6 +15,7 @@ model_metadata:
     - content: What is the mistral wind?
       role: user
   model: mistralai/Mistral-7B-Instruct-v0.1
+  repo_id: mistralai/Mistral-7B-Instruct-v0.1
   pretty_name: Mistral 7B Chat
   tags:
   - text-generation

--- a/mistral/mistral-7b-instruct-chat-trt-llm/config.yaml
+++ b/mistral/mistral-7b-instruct-chat-trt-llm/config.yaml
@@ -37,5 +37,6 @@ resources:
   use_gpu: true
 runtime:
   predict_concurrency: 256
-secrets: {}
+secrets:
+  hf_access_token: "ENTER HF ACCESS TOKEN HERE"
 system_packages: []

--- a/mistral/mistral-7b-instruct-chat-trt-llm/config.yaml
+++ b/mistral/mistral-7b-instruct-chat-trt-llm/config.yaml
@@ -26,6 +26,7 @@ model_metadata:
   - openai-compatible
   tensor_parallelism: 1
   tokenizer_repository: mistralai/Mistral-7B-Instruct-v0.2
+  repo_id: mistralai/Mistral-7B-Instruct-v0.2
 model_name: Mistral 7B Instruct Chat TRT-LLM
 python_version: py311
 requirements:

--- a/mistral/mistral-7b-instruct/config.yaml
+++ b/mistral/mistral-7b-instruct/config.yaml
@@ -8,6 +8,7 @@ model_cache:
   - '*.model'
   repo_id: mistralai/Mistral-7B-Instruct-v0.2
 model_metadata:
+  repo_id: mistralai/Mistral-7B-Instruct-v0.2
   avatar_url: https://cdn.baseten.co/production/static/explore/mistral_logo.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/mistral.png
   example_model_input:


### PR DESCRIPTION
# Summary

After mistral started requiring accepting terms, we need to start including the hf_access_token in secrets.

Note that for the TRT model, the code already sets the hf_access_token if it's in the secrets (it was generated from some template).

Note that I also added a "model_metadata.repo_id" field to the mistral-7b-chat and instruct models as well so that the terms and conditions link shows up properly.

# Testing

Deployed the model on my account:

```
$ truss push --publish --wait --remote baseten --trusted
```