### PR TITLE
reduce Llama 3 70B from 4 to 2 H100s

### DIFF
--- a/llama/llama-3-70b-instruct/config.yaml
+++ b/llama/llama-3-70b-instruct/config.yaml
@@ -14,7 +14,7 @@ requirements:
   - transformers
   - torch
 resources:
-  accelerator: H100:4
+  accelerator: H100:2
   use_gpu: true
 secrets:
   hf_access_token: "your api key"


### PR DESCRIPTION
Llama 3 70B only needs 2, not 4, 80 GB GPUs to run inference. I've changed the config and tested the updated config in production.