### PR TITLE
Fixed deploying whisper streaming to baseten by removing python executable path in config file

### DIFF
--- a/whisper/whisper-streaming/config.yaml
+++ b/whisper/whisper-streaming/config.yaml
@@ -1,6 +1,5 @@
 base_image:
   image: baseten/truss-server-base:3.10-gpu-v0.4.9
-  python_executable_path: /usr/bin/python3
 environment_variables: {}
 external_package_dirs: []
 model_metadata:


### PR DESCRIPTION
I was trying to deploy whisper streaming on baseten but I was getting error Invalid relative python executable path /usr/bin/python3 in config.yaml file.
after removing the model deployed successfully to baseten.