### PR TITLE
Update truss examples to not use py38.

### DIFF
--- a/alpaca-7b/config.yaml
+++ b/alpaca-7b/config.yaml
@@ -18,7 +18,7 @@ model_metadata:
   tags:
   - text-generation
 model_name: Alpaca 7B
-python_version: py38
+python_version: py39
 requirements:
 - torch==2.0.1
 - peft==0.3.0

--- a/code-llama-7b-instruct/config.yaml
+++ b/code-llama-7b-instruct/config.yaml
@@ -9,7 +9,7 @@ model_metadata:
   tags:
   - text-generation
 model_name: Code Llama 7B Instruct
-python_version: py38
+python_version: py39
 requirements:
 - accelerate==0.23.0
 - bitsandbytes==0.41.1

--- a/llama/llama-2-13b-chat/config.yaml
+++ b/llama/llama-2-13b-chat/config.yaml
@@ -20,7 +20,7 @@ model_metadata:
   tags:
   - text-generation
 model_name: LLaMA 2 13B Chat
-python_version: py38
+python_version: py39
 requirements:
 - accelerate==0.22.0
 - bitsandbytes==0.41.1

--- a/llama/llama-2-70b-chat/config.yaml
+++ b/llama/llama-2-70b-chat/config.yaml
@@ -20,7 +20,7 @@ model_metadata:
   tags:
   - text-generation
 model_name: LLaMA 2 70B Chat
-python_version: py38
+python_version: py39
 requirements:
 - accelerate==0.22.0
 - bitsandbytes==0.41.1

--- a/llama/llama-2-7b-chat/config.yaml
+++ b/llama/llama-2-7b-chat/config.yaml
@@ -20,7 +20,7 @@ model_metadata:
   tags:
   - text-generation
 model_name: Llama-2-chat 7B
-python_version: py38
+python_version: py39
 requirements:
 - accelerate==0.22.0
 - bitsandbytes==0.41.1

--- a/llama/llama-7b/config.yaml
+++ b/llama/llama-7b/config.yaml
@@ -18,7 +18,7 @@ model_metadata:
   tags:
   - text-generation
 model_name: LLaMA 7B
-python_version: py38
+python_version: py310
 requirements:
 - torch==2.0.1
 - peft==0.3.0

--- a/stablelm/config.yaml
+++ b/stablelm/config.yaml
@@ -9,7 +9,7 @@ model_metadata:
   tags:
   - text-generation
 model_name: StableLM
-python_version: py38
+python_version: py39
 requirements:
 - torch==2.0.1
 - peft==0.3.0


### PR DESCRIPTION
We incremented the minimum python version for truss to 3.9. A bunch of our examples were still using py38.

# Testing

I deployed the llama-2-7b-chat model successfully.

# Follow-up

Redeploy the model library model