### PR TITLE
Make LoRA truss work in baseten development mode

### DIFF
--- a/lora/config.yaml
+++ b/lora/config.yaml
@@ -38,3 +38,5 @@ resources:
 runtime:
   num_workers: 1
   predict_concurrency: 512
+system_packages:
+  - python3.10-venv


### PR DESCRIPTION
This system packages is needed by the control server in Baseten development model.