### PR TITLE
Added whisper model that takes base64 input.

### DIFF
--- a/whisper/whisper-v3-truss-base64/README.md
+++ b/whisper/whisper-v3-truss-base64/README.md
@@ -1,0 +1,75 @@
+# Whisper v3 Truss
+
+[Whisper](https://github.com/openai/whisper) is a open-source speech-to-text model by [OpenAI](https://openai.com/blog/whisper/) that transcribes audio in dozens of languages with remarkable accuracy.
+
+Whisper v3 has the same architecture as the previous model but has made the following improvements:
+- The large-v3 model is trained on 1 million hours of weakly labeled audio and 4 million hours of pseudolabeled audio collected using large-v2
+- This version has a 10-20% lower rate of error compared to the previous version when benchmarked on `Common Voice 15` and `Fleurs` dataset
+
+
+## Deploying Whisper
+
+Before deployment:
+
+1. Make sure you have a [Baseten account](https://app.baseten.co/signup) and [API key](https://app.baseten.co/settings/account/api_keys).
+2. Install the latest version of Truss: `pip install --upgrade truss`
+
+With `whisper-v3-truss` as your working directory, you can deploy the model with:
+
+```
+truss push
+```
+
+Paste your Baseten API key if prompted.
+
+For more information, see [Truss documentation](https://truss.baseten.co).
+
+## Invoking Whisper
+
+Once the model is deployed, you can invoke it with:
+
+```python
+import requests
+import base64
+
+
+audio_base64 = base64.b64encode(open("Gettysburg.mp3", "rb").read()).decode('utf-8')
+
+resp = requests.post(
+    "https://model-{MODEL_ID}.api.baseten.co/development/predict",
+    headers={"Authorization": "Api-Key $BASETEN_API_KEY"},
+    json={'audio': audio_base64},
+)
+
+print(resp.content)
+```
+
+### Whisper API documentation
+
+#### Input
+
+This deployment of Whisper takes input as a JSON dictionary with the key `audio` corresponding to a base64 encoded audio file. Here is an example input JSON:
+
+```json
+{
+    "audio": "YmG4DdeoS0HEV..."
+}
+```
+
+#### Output
+
+The model returns a fairly lengthy dictionary. For most uses, you'll be interested in the key `language` which specifies the detected language of the audio and `text` which contains the full transcription.
+
+```json
+{
+    "language": "english",
+    "segments": [
+        {
+        "start": 0,
+        "end": 11.52,
+        "text": "Four score and seven years ago our fathers brought forth upon this continent a new nation conceived in liberty and dedicated to the proposition that all men are created equal."
+        }
+    ],
+    "text": "Four score and seven years ago our fathers brought forth upon this continent a new nation conceived in liberty and dedicated to the proposition that all men are created equal."
+}
+```

--- a/whisper/whisper-v3-truss-base64/config.yaml
+++ b/whisper/whisper-v3-truss-base64/config.yaml
@@ -1,0 +1,24 @@
+description: Transcribe audio files across multiple languages.
+environment_variables: {}
+external_data:
+- local_data_path: weights/large-v3.pt
+  url: https://openaipublic.azureedge.net/main/whisper/models/e5b1a55b89c1367dacf97e3e19bfd829a01529dbfdeefa8caeb59b3f1b81dadb/large-v3.pt
+external_package_dirs: []
+model_metadata:
+  avatar_url: https://cdn.baseten.co/production/static/openai.png
+  cover_image_url: https://cdn.baseten.co/production/static/whisper.png
+  example_model_input:
+    url: https://cdn.baseten.co/docs/production/Gettysburg.mp3
+model_name: Whisper V3 Base64 Input
+python_version: py310
+requirements:
+- torch==2.0.1
+- openai-whisper==20231106
+resources:
+  accelerator: T4
+  cpu: '3'
+  memory: 16Gi
+  use_gpu: true
+secrets: {}
+system_packages:
+- ffmpeg

--- a/whisper/whisper-v3-truss-base64/model/model.py
+++ b/whisper/whisper-v3-truss-base64/model/model.py
@@ -1,0 +1,41 @@
+import base64
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Dict
+
+import requests
+import torch
+
+import whisper
+
+
+class Model:
+    def __init__(self, **kwargs):
+        self._data_dir = kwargs["data_dir"]
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.model = None
+
+    def load(self):
+        self.model = whisper.load_model(
+            Path(str(self._data_dir)) / "weights" / "large-v3.pt", self.device
+        )
+
+    def base64_to_wav(self, base64_string, output_file_path):
+        binary_data = base64.b64decode(base64_string)
+        with open(output_file_path, "wb") as wav_file:
+            wav_file.write(binary_data)
+        return output_file_path
+
+    def predict(self, request: Dict) -> Dict:
+        with NamedTemporaryFile() as fp:
+            self.base64_to_wav(request["audio"], fp.name)
+            result = whisper.transcribe(self.model, fp.name, temperature=0)
+            segments = [
+                {"start": r["start"], "end": r["end"], "text": r["text"]}
+                for r in result["segments"]
+            ]
+        return {
+            "language": whisper.tokenizer.LANGUAGES[result["language"]],
+            "segments": segments,
+            "text": result["text"],
+        }


### PR DESCRIPTION
# Summary

Modified whisper v3 to take base64 as input.

# Testing

Deployed model, and tested with this script:

```
import requests
import base64


audio_base64 = base64.b64encode(open("Gettysburg.mp3", "rb").read()).decode('utf-8')

resp = requests.post(
    "https://model-{MODEL_ID}.api.baseten.co/development/predict",
    headers={"Authorization": "Api-Key $BASETEN_API_KEY"},
    json={'audio': audio_base64},
)

print(resp.content)
```