### PR TITLE
Bump transformers version for mistrals.

### DIFF
--- a/mistral/mistral-7b-instruct-chat-trt-llm-h100/config.yaml
+++ b/mistral/mistral-7b-instruct-chat-trt-llm-h100/config.yaml
@@ -29,7 +29,7 @@ model_name: Mistral 7B Instruct Chat TRT-LLM
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.35.0
+- transformers==4.42.3
 - jinja2==3.1.3
 resources:
   accelerator: H100

--- a/mistral/mistral-7b-instruct-chat-trt-llm-smooth-quant/config.yaml
+++ b/mistral/mistral-7b-instruct-chat-trt-llm-smooth-quant/config.yaml
@@ -29,7 +29,7 @@ model_name: Mistral 7B Instruct Chat TRT-LLM
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.34.1
+- transformers==4.42.3
 resources:
   accelerator: A100
   use_gpu: true

--- a/mistral/mistral-7b-instruct-chat-trt-llm-weights-only-quant-h100/config.yaml
+++ b/mistral/mistral-7b-instruct-chat-trt-llm-weights-only-quant-h100/config.yaml
@@ -29,7 +29,7 @@ model_name: Mistral 7B Instruct Chat TRT-LLM
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.35.0
+- transformers==4.42.3
 - jinja2==3.1.3
 resources:
   accelerator: H100

--- a/mistral/mistral-7b-instruct-chat-trt-llm-weights-only-quant/config.yaml
+++ b/mistral/mistral-7b-instruct-chat-trt-llm-weights-only-quant/config.yaml
@@ -29,7 +29,7 @@ model_name: Mistral 7B Instruct Chat TRT-LLM
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.34.1
+- transformers==4.42.3
 resources:
   accelerator: A100
   use_gpu: true

--- a/mistral/mistral-7b-instruct-chat-trt-llm/config.yaml
+++ b/mistral/mistral-7b-instruct-chat-trt-llm/config.yaml
@@ -31,7 +31,7 @@ model_name: Mistral 7B Instruct Chat TRT-LLM
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.35.0
+- transformers==4.42.3
 - jinja2
 resources:
   accelerator: A100

--- a/mistral/mistral-7b-trt-llm-build-engine/config.yaml
+++ b/mistral/mistral-7b-trt-llm-build-engine/config.yaml
@@ -29,7 +29,7 @@ python_version: py311
 requirements:
 - tritonclient[all]
 - pynvml==11.5.0
-- transformers==4.35.0
+- transformers==4.42.3
 resources:
   accelerator: A100
   use_gpu: true

--- a/mistral/mixtral-8x22b-trt-int8-weights-only/config.yaml
+++ b/mistral/mixtral-8x22b-trt-int8-weights-only/config.yaml
@@ -29,7 +29,7 @@ model_name: Mixtral 8x22B Instruct TRT-LLM Weights Only Quantized
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.40.1
+- transformers==4.42.3
 resources:
   accelerator: A100:4
   use_gpu: true

--- a/mistral/mixtral-8x22b/config.yaml
+++ b/mistral/mixtral-8x22b/config.yaml
@@ -13,7 +13,7 @@ model_name: Mixtral 8x22
 python_version: py310
 requirements:
   - accelerate
-  - transformers==4.39.3
+  - transformers==4.42.3
   - torch==2.2.0
 resources:
   accelerator: A100:4

--- a/mistral/mixtral-8x7b-instruct-trt-llm-h100/config.yaml
+++ b/mistral/mixtral-8x7b-instruct-trt-llm-h100/config.yaml
@@ -30,7 +30,7 @@ model_name: Mixtral 8x7B Instruct TRT-LLM for H100
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.36.0
+- transformers==4.42.3
 - jinja2==3.1.3
 - hf_transfer==0.1.5
 resources:

--- a/mistral/mixtral-8x7b-instruct-trt-llm-weights-only-quant-h100/config.yaml
+++ b/mistral/mixtral-8x7b-instruct-trt-llm-weights-only-quant-h100/config.yaml
@@ -30,7 +30,7 @@ model_name: Mixtral 8x7B Instruct TRT-LLM Weights Only Quantized for H100
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.36.0
+- transformers==4.42.3
 - jinja2==3.1.3
 - hf_transfer==0.1.5
 resources:

--- a/mistral/mixtral-8x7b-instruct-trt-llm-weights-only-quant/config.yaml
+++ b/mistral/mixtral-8x7b-instruct-trt-llm-weights-only-quant/config.yaml
@@ -30,7 +30,7 @@ model_name: Mixtral 8x7B Instruct TRT-LLM Weights Only Quantized
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.36.0
+- transformers==4.42.3
 resources:
   accelerator: A100
   use_gpu: true

--- a/mistral/mixtral-8x7b-instruct-trt-llm/config.yaml
+++ b/mistral/mixtral-8x7b-instruct-trt-llm/config.yaml
@@ -29,7 +29,7 @@ model_name: Mixtral 8x7B Instruct TRT-LLM
 python_version: py311
 requirements:
 - tritonclient[all]
-- transformers==4.36.0
+- transformers==4.42.3
 resources:
   accelerator: A100:2
   use_gpu: true


### PR DESCRIPTION
# Context

There was a recent change to the Mistral repo on huggingface where they started using a newer transformer feature: This resulted in this: https://github.com/huggingface/transformers/issues/31789.

Bumping the transformers to fix this across all of our mistral models. As a follow-up, we should start pinning the HF repository for all of our examples to prevent this from happening.

# Testing

I have  tested a couple of the TRT examples, but not _everything_