### PR TITLE
update vllm to 0.6.0 for llama 3.1

### DIFF
--- a/llama/llama-3_1-405b-instruct/config.yaml
+++ b/llama/llama-3_1-405b-instruct/config.yaml
@@ -5,8 +5,8 @@ model_metadata:
   repo_id: meta-llama/Meta-Llama-3.1-405B-Instruct-FP8
   tensor_parallel: 8
 requirements:
-  - vllm==0.5.3post1
-  - transformers==4.43.1
+  - vllm==0.6.0
+  - transformers==4.43.2
 resources:
   accelerator: H100:8
   use_gpu: true

--- a/llama/llama-3_1-8b-instruct/config.yaml
+++ b/llama/llama-3_1-8b-instruct/config.yaml
@@ -5,7 +5,7 @@ model_metadata:
   repo_id: meta-llama/Meta-Llama-3.1-8B-Instruct
   tensor_parallel: 1
 requirements:
-  - vllm==0.5.3post1
+  - vllm==0.6.0
 model_cache:
   - repo_id: meta-llama/Meta-Llama-3.1-8B-Instruct
     ignore_patterns:

--- a/llama/llama-3_1_70b-instruct/config.yaml
+++ b/llama/llama-3_1_70b-instruct/config.yaml
@@ -4,7 +4,7 @@ model_metadata: {}
 model_name: Llama 3.1 70B vLLM
 python_version: py310
 requirements:
-  - vllm==0.5.3post1
+  - vllm==0.6.0
   - accelerate
 resources:
   accelerator: A100:4


### PR DESCRIPTION
As titled. I've tested llama/llama-3_1-8b-instruct on https://app.baseten.co/. Since I have only tested Llama 3.1, I have only made changes to these. I may upgrade the vllm versions of other models in the future.

Hi @pankajroark @philipkiely-baseten May you help review this PR? Thanks.