### PR TITLE
Fixed stream=True option for VLLM template

### DIFF
--- a/phi/phi-3.5-mini/config.yaml
+++ b/phi/phi-3.5-mini/config.yaml
@@ -1,7 +1,7 @@
 model_name: "Phi 3.5 Mini Instruct VLLM openai compatible"
 python_version: py311
 model_metadata:
-  example_model_input: {"prompt": "what is the meaning of life"}
+  example_model_input: {"messages": [{"role": "user", "content": "what is the meaning of life"}]}
   repo_id: microsoft/Phi-3.5-mini-instruct
   openai_compatible: true
   vllm_config:

--- a/phi/phi-3.5-mini/model/model.py
+++ b/phi/phi-3.5-mini/model/model.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import subprocess
@@ -142,7 +143,7 @@ class Model:
         if "messages" not in model_input and "prompt" not in model_input:
             raise ValueError("Prompt or messages must be provided")
 
-        stream = model_input.pop("stream", False)
+        stream = model_input.get("stream", False)
         if self.openai_compatible:
             # if the key metrics: true is present, let's return the vLLM /metrics endpoint
             if model_input.get("metrics", False):
@@ -157,7 +158,6 @@ class Model:
                 model_input["model"] = self._model_repo_id
 
             if stream:
-
                 async def generator():
                     async with self._client.stream(
                         "POST",

--- a/phi/phi-3.5-mini/model/model.py
+++ b/phi/phi-3.5-mini/model/model.py
@@ -157,6 +157,7 @@ class Model:
                 model_input["model"] = self._model_repo_id
 
             if stream:
+
                 async def generator():
                     async with self._client.stream(
                         "POST",
@@ -206,7 +207,7 @@ class Model:
                 full_text = ""
                 async for output in vllm_generator:
                     text = output.outputs[0].text
-                    delta = text[len(full_text):]
+                    delta = text[len(full_text) :]
                     full_text = text
                     yield delta
 

--- a/phi/phi-3.5-mini/model/model.py
+++ b/phi/phi-3.5-mini/model/model.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import subprocess
@@ -207,7 +206,7 @@ class Model:
                 full_text = ""
                 async for output in vllm_generator:
                     text = output.outputs[0].text
-                    delta = text[len(full_text) :]
+                    delta = text[len(full_text):]
                     full_text = text
                     yield delta
 

--- a/vllm/model/model.py
+++ b/vllm/model/model.py
@@ -142,7 +142,7 @@ class Model:
         if "messages" not in model_input and "prompt" not in model_input:
             raise ValueError("Prompt or messages must be provided")
 
-        stream = model_input.pop("stream", False)
+        stream = model_input.get("stream", False)
         if self.openai_compatible:
             # if the key metrics: true is present, let's return the vLLM /metrics endpoint
             if model_input.get("metrics", False):
@@ -157,7 +157,6 @@ class Model:
                 model_input["model"] = self._model_repo_id
 
             if stream:
-
                 async def generator():
                     async with self._client.stream(
                         "POST",

--- a/vllm/model/model.py
+++ b/vllm/model/model.py
@@ -157,6 +157,7 @@ class Model:
                 model_input["model"] = self._model_repo_id
 
             if stream:
+
                 async def generator():
                     async with self._client.stream(
                         "POST",
@@ -206,7 +207,7 @@ class Model:
                 full_text = ""
                 async for output in vllm_generator:
                     text = output.outputs[0].text
-                    delta = text[len(full_text):]
+                    delta = text[len(full_text) :]
                     full_text = text
                     yield delta
 

--- a/vllm/model/model.py
+++ b/vllm/model/model.py
@@ -206,7 +206,7 @@ class Model:
                 full_text = ""
                 async for output in vllm_generator:
                     text = output.outputs[0].text
-                    delta = text[len(full_text) :]
+                    delta = text[len(full_text):]
                     full_text = text
                     yield delta
 


### PR DESCRIPTION
Currently when we process `model_input`, we popped the "stream" property. 

We want to maintain this property when openAI compatible mode is enabled so stream works with openAI SDK calls