### PR TITLE
Standardize Llama and Mistral models with engine builder

### DIFF
--- a/llama/engine-llama-3-0-70b-instruct/README.md
+++ b/llama/engine-llama-3-0-70b-instruct/README.md
@@ -1,0 +1,5 @@
+# Llama 3 70B Instruct
+
+This deployment of Llama 3 70B Instruct uses the TensorRT-LLM Engine Builder.
+
+For details, see: https://docs.baseten.co/performance/examples/llama-trt

--- a/llama/engine-llama-3-0-70b-instruct/config.yaml
+++ b/llama/engine-llama-3-0-70b-instruct/config.yaml
@@ -1,0 +1,43 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are a pirate chatbot who always responds in pirate speak!"
+      },
+      {
+        role: "user",
+        content: "Who are you?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512
+  }
+  repo_id: meta-llama/Meta-Llama-3-70B-Instruct
+model_name: Llama 3.0 70B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: A100:4
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets:
+  hf_access_token: set token in baseten workspace
+system_packages: []
+trt_llm:
+  build:
+    base_model: llama
+    checkpoint_repository:
+      repo: meta-llama/Meta-Llama-3-70B-Instruct
+      source: HF
+    max_batch_size: 32
+    max_beam_width: 1
+    max_input_len: 8192
+    max_output_len: 8192
+    num_builder_gpus: 4
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/llama/engine-llama-3-0-8b-instruct/README.md
+++ b/llama/engine-llama-3-0-8b-instruct/README.md
@@ -1,0 +1,5 @@
+# Llama 3 8B Instruct
+
+This deployment of Llama 3 8B Instruct uses the TensorRT-LLM Engine Builder.
+
+For details, see: https://docs.baseten.co/performance/examples/llama-trt

--- a/llama/engine-llama-3-0-8b-instruct/config.yaml
+++ b/llama/engine-llama-3-0-8b-instruct/config.yaml
@@ -1,0 +1,43 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are a pirate chatbot who always responds in pirate speak!"
+      },
+      {
+        role: "user",
+        content: "Who are you?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512
+  }
+  repo_id: meta-llama/Meta-Llama-3-8B-Instruct
+model_name: Llama 3.0 8B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: A100
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets:
+  hf_access_token: set token in baseten workspace
+system_packages: []
+trt_llm:
+  build:
+    base_model: llama
+    checkpoint_repository:
+      repo: meta-llama/Meta-Llama-3-8B-Instruct
+      source: HF
+    max_batch_size: 32
+    max_beam_width: 1
+    max_input_len: 8192
+    max_output_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/llama/engine-llama-3-1-70b-instruct/README.md
+++ b/llama/engine-llama-3-1-70b-instruct/README.md
@@ -1,0 +1,5 @@
+# Llama 3.1 70B Instruct
+
+This deployment of Llama 3.1 70B Instruct uses the TensorRT-LLM Engine Builder.
+
+For details, see: https://docs.baseten.co/performance/examples/llama-trt

--- a/llama/engine-llama-3-1-70b-instruct/config.yaml
+++ b/llama/engine-llama-3-1-70b-instruct/config.yaml
@@ -1,0 +1,43 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are a pirate chatbot who always responds in pirate speak!"
+      },
+      {
+        role: "user",
+        content: "Who are you?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512
+  }
+  repo_id: meta-llama/Llama-3.1-70B-Instruct
+model_name: Llama 3.1 70B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: A100:4
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets:
+  hf_access_token: set token in baseten workspace
+system_packages: []
+trt_llm:
+  build:
+    base_model: llama
+    checkpoint_repository:
+      repo: meta-llama/Llama-3.1-70B-Instruct
+      source: HF
+    max_batch_size: 32
+    max_beam_width: 1
+    max_input_len: 8192
+    max_output_len: 8192
+    num_builder_gpus: 4
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/llama/engine-llama-3-1-8b-instruct/README.md
+++ b/llama/engine-llama-3-1-8b-instruct/README.md
@@ -1,0 +1,5 @@
+# Llama 3.1 8B Instruct
+
+This deployment of Llama 3.1 8B Instruct uses the TensorRT-LLM Engine Builder.
+
+For details, see: https://docs.baseten.co/performance/examples/llama-trt

--- a/llama/engine-llama-3-1-8b-instruct/config.yaml
+++ b/llama/engine-llama-3-1-8b-instruct/config.yaml
@@ -1,0 +1,43 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are a pirate chatbot who always responds in pirate speak!"
+      },
+      {
+        role: "user",
+        content: "Who are you?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512
+  }
+  repo_id: meta-llama/Llama-3.1-8B-Instruct
+model_name: Llama 3.1 8B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: A100
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets:
+  hf_access_token: set token in baseten workspace
+system_packages: []
+trt_llm:
+  build:
+    base_model: llama
+    checkpoint_repository:
+      repo: meta-llama/Llama-3.1-8B-Instruct
+      source: HF
+    max_batch_size: 32
+    max_beam_width: 1
+    max_input_len: 8192
+    max_output_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/mistral/engine-mistral-7b-instruct/README.md
+++ b/mistral/engine-mistral-7b-instruct/README.md
@@ -1,0 +1,5 @@
+# Mistral 7B Instruct
+
+This deployment of Mistral 7B Instruct uses the TensorRT-LLM Engine Builder.
+
+For details, see: https://docs.baseten.co/performance/examples/mistral-trt

--- a/mistral/engine-mistral-7b-instruct/config.yaml
+++ b/mistral/engine-mistral-7b-instruct/config.yaml
@@ -1,0 +1,43 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are a pirate chatbot who always responds in pirate speak!"
+      },
+      {
+        role: "user",
+        content: "Who are you?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512
+  }
+  repo_id: mistralai/Mistral-7B-Instruct-v0.3
+model_name: Mistral 7B Instruct Test
+python_version: py39
+requirements: []
+resources:
+  accelerator: A100
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets:
+  hf_access_token: set token in baseten workspace
+system_packages: []
+trt_llm:
+  build:
+    base_model: mistral
+    checkpoint_repository:
+      repo: mistralai/Mistral-7B-Instruct-v0.3
+      source: HF
+    max_batch_size: 32
+    max_beam_width: 1
+    max_input_len: 8192
+    max_output_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/mistral/engine-mixtral-8x22b-instruct/README.md
+++ b/mistral/engine-mixtral-8x22b-instruct/README.md
@@ -1,0 +1,5 @@
+# Mistral 8x22B Instruct
+
+This deployment of Mistral 8x22B Instruct uses the TensorRT-LLM Engine Builder.
+
+For details, see: https://docs.baseten.co/performance/examples/mistral-trt

--- a/mistral/engine-mixtral-8x22b-instruct/config.yaml
+++ b/mistral/engine-mixtral-8x22b-instruct/config.yaml
@@ -1,0 +1,43 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are a pirate chatbot who always responds in pirate speak!"
+      },
+      {
+        role: "user",
+        content: "Who are you?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512
+  }
+  repo_id: mistralai/Mixtral-8x22B-Instruct-v0.1
+model_name: Mistral 7B Instruct Test
+python_version: py39
+requirements: []
+resources:
+  accelerator: A100:4
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets:
+  hf_access_token: set token in baseten workspace
+system_packages: []
+trt_llm:
+  build:
+    base_model: mistral
+    checkpoint_repository:
+      repo: mistralai/Mixtral-8x22B-Instruct-v0.1
+      source: HF
+    max_batch_size: 32
+    max_beam_width: 1
+    max_input_len: 8192
+    max_output_len: 8192
+    num_builder_gpus: 4
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/mistral/engine-mixtral-8x7b-instruct/README.md
+++ b/mistral/engine-mixtral-8x7b-instruct/README.md
@@ -1,0 +1,5 @@
+# Mistral 8x7B Instruct
+
+This deployment of Mistral 8x7B Instruct uses the TensorRT-LLM Engine Builder.
+
+For details, see: https://docs.baseten.co/performance/examples/mistral-trt

--- a/mistral/engine-mixtral-8x7b-instruct/config.yaml
+++ b/mistral/engine-mixtral-8x7b-instruct/config.yaml
@@ -1,0 +1,43 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are a pirate chatbot who always responds in pirate speak!"
+      },
+      {
+        role: "user",
+        content: "Who are you?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512
+  }
+  repo_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+model_name: Mistral 8x7B Instruct Test
+python_version: py39
+requirements: []
+resources:
+  accelerator: A100:2
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets:
+  hf_access_token: set token in baseten workspace
+system_packages: []
+trt_llm:
+  build:
+    base_model: mistral
+    checkpoint_repository:
+      repo: mistralai/Mixtral-8x7B-Instruct-v0.1
+      source: HF
+    max_batch_size: 32
+    max_beam_width: 1
+    max_input_len: 8192
+    max_output_len: 8192
+    num_builder_gpus: 2
+    quantization_type: no_quant
+    tensor_parallel_count: 1


### PR DESCRIPTION
The library currently has various implementations of Llama and Mistral models with differing optimizations and interfaces.

This PR is part of a project to standardize everything using the engine builder. Updates will be made separately in Dato.