### PR TITLE
Add 8 Qwen models to the model library

### DIFF
--- a/qwen/engine-qwen-2-5-14b-coder-instruct/README.md
+++ b/qwen/engine-qwen-2-5-14b-coder-instruct/README.md
@@ -1,0 +1,5 @@
+# Qwen Coder 2.5 14B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen Coder 2.5 14B Instruct.
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-14b-coder-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-14b-coder-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+      },
+      {
+        role: "user",
+        content: "Write a Python script for fizzbuzz."
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-Coder-14B-Instruct
+model_name: Qwen Coder 2.5 14B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-Coder-14B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/qwen/engine-qwen-2-5-14b-instruct/README.md
+++ b/qwen/engine-qwen-2-5-14b-instruct/README.md
@@ -1,0 +1,5 @@
+# Qwen 2.5 14B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen 2.5 14B Instruct.
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-14b-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-14b-instruct/config.yaml
@@ -1,0 +1,34 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input:
+    max_tokens: 512
+    messages:
+    - content: You are Qwen, created by Alibaba Cloud. You are a helpful assistant.
+      role: system
+    - content: What does Tongyi Qianwen mean?
+      role: user
+    stream: true
+    temperature: 0.9
+  repo_id: Qwen/Qwen2.5-14B-Instruct
+model_name: Qwen 2.5 14B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-14B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/qwen/engine-qwen-2-5-32b-coder-instruct/README.md
+++ b/qwen/engine-qwen-2-5-32b-coder-instruct/README.md
@@ -1,0 +1,5 @@
+# Qwen Coder 2.5 32B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen Coder 2.5 32B Instruct.
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-32b-coder-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-32b-coder-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+      },
+      {
+        role: "user",
+        content: "Write a Python script for fizzbuzz."
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-Coder-32B-Instruct
+model_name: Qwen Coder 2.5 32B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-Coder-32B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 1
+    quantization_type: fp8_kv
+    tensor_parallel_count: 1

--- a/qwen/engine-qwen-2-5-32b-instruct/README.md
+++ b/qwen/engine-qwen-2-5-32b-instruct/README.md
@@ -1,0 +1,5 @@
+# Qwen 2.5 32B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen 2.5 32B Instruct.
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-32b-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-32b-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+      },
+      {
+        role: "user",
+        content: "What does Tongyi Qianwen mean?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-32B-Instruct
+model_name: Qwen 2.5 32B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-32B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 1
+    quantization_type: fp8_kv
+    tensor_parallel_count: 1

--- a/qwen/engine-qwen-2-5-3b-instruct/README.md
+++ b/qwen/engine-qwen-2-5-3b-instruct/README.md
@@ -1,0 +1,5 @@
+# Qwen 2.5 3B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen 2.5 3B Instruct.
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-3b-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-3b-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+      },
+      {
+        role: "user",
+        content: "What does Tongyi Qianwen mean?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-3B-Instruct
+model_name: Qwen 2.5 3B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: A10G
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-3B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/qwen/engine-qwen-2-5-72b-instruct/README.md
+++ b/qwen/engine-qwen-2-5-72b-instruct/README.md
@@ -1,0 +1,7 @@
+# Qwen 2.5 72B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen 2.5 72B Instruct.
+
+Note that while other sizes of Qwen 2.5 are licensed as Apache 2.0, 72B sizes use the [qwen license](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct/blob/main/LICENSE).
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-72b-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-72b-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+      },
+      {
+        role: "user",
+        content: "What does Tongyi Qianwen mean?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-72B-Instruct
+model_name: Qwen 2.5 72B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100:2
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-72B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 4
+    quantization_type: fp8_kv
+    tensor_parallel_count: 2

--- a/qwen/engine-qwen-2-5-72b-math-instruct/README.md
+++ b/qwen/engine-qwen-2-5-72b-math-instruct/README.md
@@ -1,0 +1,7 @@
+# Qwen Math 2.5 72B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen Math 2.5 72B Instruct.
+
+Note that while other sizes of Qwen 2.5 are licensed as Apache 2.0, 72B sizes use the [qwen license](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct/blob/main/LICENSE).
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-72b-math-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-72b-math-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "Please reason step by step, and put your final answer within \\boxed{}."
+      },
+      {
+        role: "user",
+        content: "Find the value of $x$ that satisfies the equation $4x+5 = 6x+7$."
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-Math-72B-Instruct
+model_name: Qwen Math 2.5 72B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100:2
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-Math-72B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 4
+    quantization_type: fp8_kv
+    tensor_parallel_count: 2

--- a/qwen/engine-qwen-2-5-7b-coder-instruct/README.md
+++ b/qwen/engine-qwen-2-5-7b-coder-instruct/README.md
@@ -1,0 +1,5 @@
+# Qwen Coder 2.5 7B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen Coder 2.5 7B Instruct.
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-7b-coder-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-7b-coder-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+      },
+      {
+        role: "user",
+        content: "Write a Python script for fizzbuzz."
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-Coder-7B-Instruct
+model_name: Qwen Coder 2.5 7B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100_40GB
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-Coder-7B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/qwen/engine-qwen-2-5-7b-instruct/README.md
+++ b/qwen/engine-qwen-2-5-7b-instruct/README.md
@@ -1,0 +1,5 @@
+# Qwen 2.5 7B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen 2.5 7B Instruct.
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-7b-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-7b-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+      },
+      {
+        role: "user",
+        content: "What does Tongyi Qianwen mean?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-7B-Instruct
+model_name: Qwen 2.5 7B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100_40GB
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-7B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1

--- a/qwen/engine-qwen-2-5-7b-math-instruct/README.md
+++ b/qwen/engine-qwen-2-5-7b-math-instruct/README.md
@@ -1,0 +1,5 @@
+# Qwen Math 2.5 7B Instruct Engine
+
+This example uses the [TensorRT-LLM Engine Builder for Qwen](https://docs.baseten.co/performance/examples/qwen-trt) to build and deploy an optimized inference engine for Qwen Math 2.5 7B Instruct.
+
+For advanced control over the engine building process, see [engine control in Python](https://docs.baseten.co/performance/engine-builder-customization) and [engine builder configuration](https://docs.baseten.co/performance/engine-builder-config) docs.

--- a/qwen/engine-qwen-2-5-7b-math-instruct/config.yaml
+++ b/qwen/engine-qwen-2-5-7b-math-instruct/config.yaml
@@ -1,0 +1,40 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  example_model_input: {
+    messages: [
+      {
+        role: "system",
+        content: "Please reason step by step, and put your final answer within \\boxed{}."
+      },
+      {
+        role: "user",
+        content: "Find the value of $x$ that satisfies the equation $4x+5 = 6x+7$."
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: Qwen/Qwen2.5-Math-7B-Instruct
+model_name: Qwen Math 2.5 7B Instruct
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100_40GB
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets: {}
+system_packages: []
+trt_llm:
+  build:
+    base_model: qwen
+    checkpoint_repository:
+      repo: Qwen/Qwen2.5-Math-7B-Instruct
+      source: HF
+    max_seq_len: 8192
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1


### PR DESCRIPTION
Using the latest edition of the engine builder, this PR adds all 8 qwen 2.5 sizes/variants that we want to use in the model library.

I have manually deployed and tested all 8 of these models to ensure they are working correctly.