### PR TITLE
Improve truss examples CI script

### DIFF
--- a/bin/test_example.py
+++ b/bin/test_example.py
@@ -31,7 +31,7 @@ def write_trussrc_file(api_key: str):
     RemoteFactory.update_remote_config(ci_user)
 
 
-@retry(wait=wait_fixed(30), stop=stop_after_attempt(3), reraise=True)
+@retry(wait=wait_fixed(30), stop=stop_after_attempt(8), reraise=True)
 def attempt_inference(truss_handle, model_version_id, api_key):
     """
     Retry every 20 seconds to call inference on the example, using the `example_model_input`
@@ -72,7 +72,9 @@ def attempt_inference(truss_handle, model_version_id, api_key):
     reraise=True,
 )
 def deploy_truss(target_directory: str) -> str:
-    model_deployment = truss.push(target_directory, remote=REMOTE_NAME)
+    model_deployment = truss.push(
+        target_directory, remote=REMOTE_NAME, trusted=True, publish=True
+    )
     model_deployment.wait_for_active()
     return model_deployment.model_deployment_id
 

--- a/bin/test_example.py
+++ b/bin/test_example.py
@@ -54,7 +54,7 @@ def attempt_inference(truss_handle, model_id, model_version_id, api_key):
     else:
         raise Exception("No example_model_input defined in Truss config")
 
-    url = f"https://model-{model_id}.api.staging.baseten.co/deployments/{model_version_id}/predict"
+    url = f"https://model-{model_id}.api.staging.baseten.co/deployment/{model_version_id}/predict"
 
     headers = {"Authorization": f"Api-Key {api_key}"}
     response = requests.post(url, headers=headers, json=example_model_input, timeout=30)

--- a/bin/test_example.py
+++ b/bin/test_example.py
@@ -66,13 +66,13 @@ def attempt_inference(truss_handle, model_version_id, api_key):
         raise Exception(f"Request failed with status code {response.status_code}")
 
 
+@retry(
+    wait=wait_random_exponential(multiplier=1, max=120),
+    stop=stop_after_attempt(3),
+    reraise=True,
+)
 def deploy_truss(target_directory: str) -> str:
-    for _ in Retrying(
-        wait=wait_random_exponential(multiplier=1, max=120),
-        stop=stop_after_attempt(5),
-        reraise=True,
-    ):
-        model_deployment = truss.push(target_directory, remote=REMOTE_NAME)
+    model_deployment = truss.push(target_directory, remote=REMOTE_NAME)
     model_deployment.wait_for_active()
     return model_deployment.model_deployment_id
 


### PR DESCRIPTION
Improves the truss examples to do the following:
* Fail immediately if there are problems (instead of having to wait 20 minutes)
* Doesn't have a 20 minute timeout if the model is still building

# Testing

Ran https://github.com/basetenlabs/truss-examples/actions/runs/11633933987/job/32400112601