### PR TITLE
fix streaming issue for token gen

### DIFF
--- a/orpheus-best-performance/model/model.py
+++ b/orpheus-best-performance/model/model.py
@@ -190,6 +190,8 @@ class Model:
         async def audio_stream():
             yield self.create_wav_header()
             token_gen = await self._engine.predict(model_input, request)
+            if isinstance(token_gen, StreamingResponse):
+                token_gen = token_gen.body_iterator
             async for chunk in tokens_decoder(token_gen):
                 yield chunk
 


### PR DESCRIPTION
Correct `token_gen` handling to grab body_iterator in the case we have that it's an instance of `StreamingResponse`.