### PR TITLE
Move whispers from T4 to A10G.

### DIFF
--- a/whisper/faster-whisper-v2/config.yaml
+++ b/whisper/faster-whisper-v2/config.yaml
@@ -19,7 +19,7 @@ requirements:
 - faster-whisper==1.0.3
 - ctranslate2==4.4.0
 resources:
-  accelerator: T4
+  accelerator: A10G
   cpu: 500m
   memory: 512Mi
   use_gpu: true

--- a/whisper/faster-whisper-v3/config.yaml
+++ b/whisper/faster-whisper-v3/config.yaml
@@ -19,7 +19,7 @@ requirements:
 - faster-whisper==1.0.3
 - ctranslate2==4.4.0
 resources:
-  accelerator: T4
+  accelerator: A10G
   cpu: 500m
   memory: 512Mi
   use_gpu: true

--- a/whisper/whisper-v3-truss/config.yaml
+++ b/whisper/whisper-v3-truss/config.yaml
@@ -16,7 +16,7 @@ requirements:
 - openai-whisper==20240930
 - ffmpeg-python==0.2.0
 resources:
-  accelerator: T4
+  accelerator: A10G
   cpu: '3'
   memory: 16Gi
   use_gpu: true


### PR DESCRIPTION
Move our whisper models to use A10G instead of T4 so that they can get instances much more easily.