### PR TITLE
Updated vLLM image version for ultravox 0.4

### DIFF
--- a/custom-server/ultravox-0.4/config.yaml
+++ b/custom-server/ultravox-0.4/config.yaml
@@ -1,5 +1,5 @@
 base_image:
-  image: vllm/vllm-openai:v0.5.5
+  image: vllm/vllm-openai:v0.8.5
 model_metadata:
   repo_id: fixie-ai/ultravox-v0.4
   avatar_url: https://cdn-avatars.huggingface.co/v1/production/uploads/628d700fdb4cd1d1717c7d2f/m9n8O1Jk88UadmN6GoLNR.png


### PR DESCRIPTION
Updated vLLM image version for ultravox 0.4 to support up to fixie-ai/ultravox-v0_5-llama-3_2-1b.

Reference https://docs.vllm.ai/en/v0.8.5/models/supported_models.html

Going from 0.5.5 to 0.8.5 