### PR TITLE
Update ubuntu version in lint GH action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python/


### PR DESCRIPTION
ubuntu 20.04 was EOLed.

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/d8cc5d59-33ee-4f6d-ba22-2b415250d075" />
