### PR TITLE
Ultravox 0.4 fixes and audio support

### DIFF
--- a/custom-server/ultravox-0.4/config.yaml
+++ b/custom-server/ultravox-0.4/config.yaml
@@ -37,4 +37,3 @@ environment_variables:
   VLLM_LOGGING_LEVEL: WARNING
 requirements:
   - vllm[audio]==0.8.5
-  

--- a/custom-server/ultravox-0.4/config.yaml
+++ b/custom-server/ultravox-0.4/config.yaml
@@ -11,11 +11,11 @@ model_metadata:
             "content": [
                 {
                     "type": "text",
-                    "text": "For like Michigan,"
+                    "text": "Four score,"
                 },
                 {
                     "type": "audio_url",
-                    "audio_url": {"url": "http://study.aitech.ac.jp/tat/239977.mp3"}
+                    "audio_url": {"url": "https://cdn.baseten.co/docs/production/Gettysburg.mp3"}
                 }
             ]
         }

--- a/custom-server/ultravox-0.4/config.yaml
+++ b/custom-server/ultravox-0.4/config.yaml
@@ -37,3 +37,4 @@ environment_variables:
   VLLM_LOGGING_LEVEL: WARNING
 requirements:
   - vllm[audio]==0.8.5
+  

--- a/custom-server/ultravox-0.4/config.yaml
+++ b/custom-server/ultravox-0.4/config.yaml
@@ -11,11 +11,11 @@ model_metadata:
             "content": [
                 {
                     "type": "text",
-                    "text": "Four score,"
+                    "text": "What is Lydia like?"
                 },
                 {
                     "type": "audio_url",
-                    "audio_url": {"url": "https://cdn.baseten.co/docs/production/Gettysburg.mp3"}
+                    "audio_url": {"url": "https://audio-samples.github.io/samples/mp3/blizzard_tts_unbiased/sample-2/real.mp3"}
                 }
             ]
         }
@@ -35,3 +35,5 @@ runtime:
 model_name: Ultravox v0.4
 environment_variables:
   VLLM_LOGGING_LEVEL: WARNING
+requirements:
+  - vllm[audio]==0.8.5

--- a/custom-server/ultravox-0.4/config.yaml
+++ b/custom-server/ultravox-0.4/config.yaml
@@ -22,7 +22,7 @@ model_metadata:
     ]
   }
 docker_server:
-  start_command: sh -c "HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve fixie-ai/ultravox-v0_4 --dtype half --max-model-len 4096 --port 8000 --served-model-name ultravox --tensor-parallel-size 1 --gpu-memory-utilization 0.95 --distributed-executor-backend mp --disable-custom-all-reduce --enforce-eager --trust-remote-code"
+  start_command: sh -c "vllm serve fixie-ai/ultravox-v0_4 --dtype half --max-model-len 4096 --port 8000 --served-model-name ultravox --tensor-parallel-size 1 --gpu-memory-utilization 0.95 --distributed-executor-backend mp --disable-custom-all-reduce --enforce-eager --trust-remote-code"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions
@@ -35,4 +35,3 @@ runtime:
 model_name: Ultravox v0.4
 environment_variables:
   VLLM_LOGGING_LEVEL: WARNING
-  hf_access_token: null


### PR DESCRIPTION
Removed HF Access Token (not needed, just causes problems for the customer)

Changed example audio to be a public URL (baseten cdn at this time has a robots.txt)

Added audio support in requirements.