### PR TITLE
Move hf_access_token to a dedicated field in config.yaml

### DIFF
--- a/custom-server/ultravox-0.4/config.yaml
+++ b/custom-server/ultravox-0.4/config.yaml
@@ -36,7 +36,5 @@ resources:
 runtime:
   predict_concurrency : 16
 model_name: Ultravox v0.4
-environment_variables:
-  VLLM_LOGGING_LEVEL: WARNING
 requirements:
   - vllm[audio]==0.9.2

--- a/custom-server/ultravox-0.5-8b/config.yaml
+++ b/custom-server/ultravox-0.5-8b/config.yaml
@@ -2,7 +2,7 @@ description: Take in audio and text as input, generating text as usual
 base_image:
   image: vllm/vllm-openai:v0.9.2
 model_metadata:
-  repo_id: fixie-ai/ultravox-v0_5-llama-3_1-8b
+  repo_id: meta-llama/Llama-3.1-8B-Instruct
   avatar_url: https://cdn-avatars.huggingface.co/v1/production/uploads/628d700fdb4cd1d1717c7d2f/m9n8O1Jk88UadmN6GoLNR.png
   example_model_input: {
     "model": "ultravox",
@@ -25,7 +25,7 @@ model_metadata:
   tags:
     - openai-compatible
 docker_server:
-  start_command: sh -c "vllm serve fixie-ai/ultravox-v0_5-llama-3_1-8b --dtype half --max-model-len 4096 --port 8000 --served-model-name ultravox --tensor-parallel-size 1 --gpu-memory-utilization 0.95 --distributed-executor-backend mp --disable-custom-all-reduce --trust-remote-code"
+  start_command: sh -c "HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve fixie-ai/ultravox-v0_5-llama-3_1-8b --dtype half --max-model-len 4096 --port 8000 --served-model-name ultravox --tensor-parallel-size 1 --gpu-memory-utilization 0.95 --distributed-executor-backend mp --disable-custom-all-reduce --trust-remote-code"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/custom-server/ultravox-0.5-8b/config.yaml
+++ b/custom-server/ultravox-0.5-8b/config.yaml
@@ -25,7 +25,7 @@ model_metadata:
   tags:
     - openai-compatible
 docker_server:
-  start_command: sh -c "HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve fixie-ai/ultravox-v0_5-llama-3_1-8b --dtype half --max-model-len 4096 --port 8000 --served-model-name ultravox --tensor-parallel-size 1 --gpu-memory-utilization 0.95 --distributed-executor-backend mp --disable-custom-all-reduce --trust-remote-code"
+  start_command: sh -c "vllm serve fixie-ai/ultravox-v0_5-llama-3_1-8b --dtype half --max-model-len 4096 --port 8000 --served-model-name ultravox --tensor-parallel-size 1 --gpu-memory-utilization 0.95 --distributed-executor-backend mp --disable-custom-all-reduce --trust-remote-code"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions
@@ -36,7 +36,7 @@ resources:
 runtime:
   predict_concurrency : 16
 model_name: Ultravox v0.5 8B
-environment_variables:
-  VLLM_LOGGING_LEVEL: WARNING
+secrets:
+  hf_access_token: null
 requirements:
   - vllm[audio]==0.9.2

--- a/custom-server/ultravox-0.5-8b/config.yaml
+++ b/custom-server/ultravox-0.5-8b/config.yaml
@@ -2,7 +2,7 @@ description: Take in audio and text as input, generating text as usual
 base_image:
   image: vllm/vllm-openai:v0.9.2
 model_metadata:
-  repo_id: meta-llama/Llama-3.1-8B-Instruct
+  repo_id: meta-llama/Llama-3.1-8B-Instruct # Ultravox uses this model under the hood, which is gated and requires hf access
   avatar_url: https://cdn-avatars.huggingface.co/v1/production/uploads/628d700fdb4cd1d1717c7d2f/m9n8O1Jk88UadmN6GoLNR.png
   example_model_input: {
     "model": "ultravox",

--- a/custom-server/ultravox-0.6-70b/config.yaml
+++ b/custom-server/ultravox-0.6-70b/config.yaml
@@ -2,7 +2,7 @@ description: Take in audio and text as input, generating text as usual
 base_image:
   image: vllm/vllm-openai:v0.9.2
 model_metadata:
-  repo_id: meta-llama/Llama-3.3-70B-Instruct
+  repo_id: meta-llama/Llama-3.3-70B-Instruct # Ultravox uses this model under the hood, which is gated and requires hf access
   avatar_url: https://cdn-avatars.huggingface.co/v1/production/uploads/628d700fdb4cd1d1717c7d2f/m9n8O1Jk88UadmN6GoLNR.png
   example_model_input: {
     "model": "ultravox",

--- a/custom-server/ultravox-0.6-70b/config.yaml
+++ b/custom-server/ultravox-0.6-70b/config.yaml
@@ -2,7 +2,7 @@ description: Take in audio and text as input, generating text as usual
 base_image:
   image: vllm/vllm-openai:v0.9.2
 model_metadata:
-  repo_id: fixie-ai/ultravox-v0_6-llama-3_3-70b
+  repo_id: meta-llama/Llama-3.3-70B-Instruct
   avatar_url: https://cdn-avatars.huggingface.co/v1/production/uploads/628d700fdb4cd1d1717c7d2f/m9n8O1Jk88UadmN6GoLNR.png
   example_model_input: {
     "model": "ultravox",
@@ -25,7 +25,7 @@ model_metadata:
   tags:
     - openai-compatible
 docker_server:
-  start_command: sh -c "vllm serve fixie-ai/ultravox-v0_6-llama-3_3-70b --dtype half --max-model-len 16384 --port 8000 --served-model-name ultravox --tensor-parallel-size 4 --gpu-memory-utilization 0.90 --distributed-executor-backend mp --disable-custom-all-reduce --trust-remote-code"
+  start_command: sh -c "HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve fixie-ai/ultravox-v0_6-llama-3_3-70b --dtype half --max-model-len 16384 --port 8000 --served-model-name ultravox --tensor-parallel-size 4 --gpu-memory-utilization 0.90 --distributed-executor-backend mp --disable-custom-all-reduce --trust-remote-code"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/custom-server/ultravox-0.6-70b/config.yaml
+++ b/custom-server/ultravox-0.6-70b/config.yaml
@@ -25,7 +25,7 @@ model_metadata:
   tags:
     - openai-compatible
 docker_server:
-  start_command: sh -c "HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve fixie-ai/ultravox-v0_6-llama-3_3-70b --dtype half --max-model-len 16384 --port 8000 --served-model-name ultravox --tensor-parallel-size 4 --gpu-memory-utilization 0.90 --distributed-executor-backend mp --disable-custom-all-reduce --trust-remote-code"
+  start_command: sh -c "vllm serve fixie-ai/ultravox-v0_6-llama-3_3-70b --dtype half --max-model-len 16384 --port 8000 --served-model-name ultravox --tensor-parallel-size 4 --gpu-memory-utilization 0.90 --distributed-executor-backend mp --disable-custom-all-reduce --trust-remote-code"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions
@@ -36,5 +36,7 @@ resources:
 runtime:
   predict_concurrency : 16
 model_name: Ultravox v0.6 70B
+secrets:
+  hf_access_token: null
 requirements:
   - vllm[audio]==0.9.2


### PR DESCRIPTION
Seems this is necessary for better readability and also to have it show up as needing the secret from the model library:

<img width="648" height="178" alt="Screenshot 2025-07-11 at 3 45 43 PM" src="https://github.com/user-attachments/assets/4017a5e8-6180-44ae-a8a1-32f232e75d9a" />

https://basetenlabs.slack.com/archives/C052AKXNGES/p1752263630617429
This change is unintuitive, but when deployed in model library, will prompt users who try to deploy the model with a hf token and also indicate the repo they need to get access to.