### PR TITLE
Demonstrate how to deploy a model on trtllm with multiple loras

### DIFF
--- a/lora/README.md
+++ b/lora/README.md
@@ -1,0 +1,59 @@
+# Mistral 7B Instruct LoRA
+
+This is an example of a truss that supports **dynamic swapping of LoRA adapters**—allowing you to serve multiple fine-tuned variants efficiently from a single GPU. In this example, we deploy a **Mistral 7B Instruct** on [TensorRT-LLM Engine Builder](https://docs.baseten.co/performance/examples/mistral-trt). This model will be an expert in finance, medicine and law.
+
+- 📄 **TensorRT-LLM Details:** [Performance Example (Baseten Docs)](https://docs.baseten.co/performance/examples/mistral-trt)
+- 💡 **LoRA Swapping Overview:** [Baseten Blog: Serving 10,000 Fine-Tuned LLMs from One GPU](https://www.baseten.co/blog/how-to-serve-10-000-fine-tuned-llms-from-a-single-gpu/)
+
+---
+
+## 🛠️ Implementing LoRA Swapping
+
+Extending a base TensorRT-LLM deployment to support LoRA swapping requires three config changes:
+
+### 1. Configure `lora_adapters`
+
+List each LoRA adapter’s name and its download source. Supported sources are:
+- `HF` for HuggingFace
+- `GCS` for Google Cloud Storage
+- `REMOTE_URL` for any direct download
+
+**Example (`config.yaml`):**
+```yaml
+lora_adapters:
+  legal:
+    source: HF
+    repo: Aretoss/Lexgen
+  finance:
+    source: HF
+    repo: vaibhav1/lora-mistral-finance
+  medical:
+    source: HF
+    repo: Imsachinsingh00/Fine_tuned_LoRA_Mistral_MTSDialog_Summarization
+```
+
+### 2. Set `served_model_name` (Optional)
+
+Set this parameter if you wish to allow requests to the base model (without any LoRA applied).
+
+---
+
+### 3. Select Adapter or Base Model at Request Time
+
+Specify the desired adapter or base model using the `model` field in your request payload.
+
+**Example request body**
+
+```json
+{
+  "model": "finance",
+  "stream": true,
+  "messages": [
+    {"role": "user", "content": "What would you choose in 2008?"}
+  ],
+  "max_tokens": 1024,
+  "temperature": 0.9
+}
+```
+
+### For full details, see [documentation](https://docs.baseten.co/development/model/performance/engine-builder-config)

--- a/lora/config.yaml
+++ b/lora/config.yaml
@@ -1,0 +1,59 @@
+build_commands: []
+environment_variables: {}
+external_package_dirs: []
+model_metadata:
+  tags:
+    - openai-compatible
+  example_model_input: {
+    model: "finance",
+    messages: [
+      {
+        role: "user",
+        content: "How would you choose back in 2008?"
+      }
+    ],
+    stream: true,
+    max_tokens: 512,
+    temperature: 0.9
+  }
+  repo_id: mistralai/Mistral-7B-Instruct-v0.3
+model_name: Mistral 7B Instruct Lora
+python_version: py39
+requirements: []
+resources:
+  accelerator: H100_40GB
+  cpu: '1'
+  memory: 24Gi
+  use_gpu: true
+secrets:
+  hf_access_token: set token in baseten workspace
+system_packages: []
+trt_llm:
+  build:
+    base_model: mistral
+    checkpoint_repository:
+      repo: mistralai/Mistral-7B-Instruct-v0.3
+      source: HF
+    lora_adapters:
+      legal:
+        source: HF
+        repo: Aretoss/Lexgen
+      finance:
+        source: HF
+        repo: vaibhav1/lora-mistral-finance
+      medical:
+        source: HF
+        repo: Imsachinsingh00/Fine_tuned_LoRA_Mistral_MTSDialog_Summarization
+    max_seq_len: 32768
+    num_builder_gpus: 1
+    quantization_type: no_quant
+    tensor_parallel_count: 1
+    plugin_configuration:
+      use_paged_context_fmha: true
+      use_fp8_context_fmha: false
+      paged_kv_cache: true
+  runtime:
+    batch_scheduler_policy: max_utilization
+    enable_chunked_context: true
+    request_default_max_tokens: 32768
+    served_model_name: mistral


### PR DESCRIPTION
This is an example of a truss that supports dynamic swapping of LoRA adapters to serve multiple fine tuned models from a single GPU. This example deploys a Mistral 7B Instruct that is an expert in finance, medicine and law.