### PR TITLE
Update `--index-url` examples, with move to `uv`

### DIFF
--- a/orpheus-best-performance/config.yaml
+++ b/orpheus-best-performance/config.yaml
@@ -18,9 +18,8 @@ model_metadata:
 model_name: Orpheus-3b
 python_version: py39
 requirements:
-  - "--index-url https://download.pytorch.org/whl/cu128"
+  - --extra-index-url https://download.pytorch.org/whl/cu128
   - torch==2.7.1
-  - "--extra-index-url https://pypi.org/simple"
   - snac==1.2.1
   - batched==0.1.4
 resources:

--- a/whisper/whisperx-truss/config.yaml
+++ b/whisper/whisperx-truss/config.yaml
@@ -9,11 +9,12 @@ model_metadata:
 model_name: whisperX
 python_version: py310
 requirements:
+- --extra-index-url https://download.pytorch.org/whl/cu121
 - git+https://github.com/m-bain/whisperx.git@734084cdf6f624bc33ed9f0cfcaa82840707ba6f
-- torch==2.2.0 --index-url https://download.pytorch.org/whl/cu121
-- torchaudio==2.2.0 --index-url https://download.pytorch.org/whl/cu121
+- torch==2.2.0
+- torchaudio==2.2.0
 - transformers==4.48.3
-- torchvision==0.17.0 --index-url https://download.pytorch.org/whl/cu121
+- torchvision==0.17.0
 - ffmpeg-python==0.2.0
 - faster-whisper==1.1.0
 - pandas==2.2.3


### PR DESCRIPTION
[Move](https://basetenlabs.slack.com/archives/C04NM3YA2DT/p1753795279056229) from `pip` to `uv` as our base installer introduced a couple issues with usage of `--index-url`. While we track down who might have run into these issues, we should update our examples so no new users have issues.