### PR TITLE
Fix ci.yaml trailing whitespace

### DIFF
--- a/ci.yaml
+++ b/ci.yaml
@@ -13,4 +13,3 @@ tests:
   - whisper/faster-whisper-v3
   - playground-v2-aesthetic
   - llama/tinyllama-1.1B-chat-v1.0
-  


### PR DESCRIPTION
This trailing whitespace is causing linters to fail in every PR.