### PR TITLE
add vllm compile caching

### DIFF
--- a/mistral/mistral-small-3.1/config.yaml
+++ b/mistral/mistral-small-3.1/config.yaml
@@ -29,7 +29,7 @@ model_metadata:
   tags:
   - openai-compatible
 docker_server:
-  start_command: "sh -c \"TORCHINDUCTOR_CACHE_DIR=~/.cache/vllm b10-compile-cache & VLLM_USE_V1=1 HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve mistralai/Mistral-Small-3.1-24B-Instruct-2503 --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice --served-model-name mistral --max-num-seqs 8 --max-model-len 16384 --tensor-parallel-size 1 --gpu-memory-utilization 0.95\""
+  start_command: "sh -c \"b10-compile-cache & VLLM_USE_V1=1 HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve mistralai/Mistral-Small-3.1-24B-Instruct-2503 --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice --served-model-name mistral --max-num-seqs 8 --max-model-len 16384 --tensor-parallel-size 1 --gpu-memory-utilization 0.95\""
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions


### PR DESCRIPTION
Add vLLM compile caching (b10-compile-cache cli) to mistral as a demo for the docs. Cuts compilation time from 50 seconds to 7 seconds, does not negatively affect vLLM init time despite background process polling.