### PR TITLE
Pin unpinned dependencies in chatterbox-tts, clip, and kokoro

### DIFF
--- a/chatterbox-tts/config.yaml
+++ b/chatterbox-tts/config.yaml
@@ -4,7 +4,7 @@ base_image:
   python_executable_path: /usr/bin/python3
 python_version: py312
 requirements:
-  - chatterbox-tts
+  - chatterbox-tts==0.1.7
 resources:
   accelerator: H100
   cpu: '1'

--- a/clip/config.yaml
+++ b/clip/config.yaml
@@ -7,8 +7,8 @@ model_name: clip-example
 python_version: py311
 requirements:
 - transformers==4.47.1
-- pillow
-- torch
+- pillow==11.1.0
+- torch==2.5.1
 resources:
   accelerator: A10G
   cpu: '3'

--- a/kokoro/config.yaml
+++ b/kokoro/config.yaml
@@ -11,8 +11,8 @@ requirements:
 - scipy==1.15.1
 - phonemizer==3.3.0
 - nltk==3.9.1
-- numpy
-- huggingface_hub[hf_transfer]
+- numpy==1.26.4
+- huggingface_hub[hf_transfer]==0.27.0
 - hf_transfer==0.1.9
 - munch==4.0.0
 resources:


### PR DESCRIPTION
Per CONTRIBUTING.md: "Pin versions for all Python requirements!"

Pins unpinned dependencies in three examples:

- **chatterbox-tts**: `chatterbox-tts` → `chatterbox-tts==0.1.7`
- **clip**: `pillow` → `pillow==11.1.0`, `torch` → `torch==2.5.1` (consistent with the already-pinned `transformers==4.47.1`)
- **kokoro**: `numpy` → `numpy==1.26.4`, `huggingface_hub[hf_transfer]` → `huggingface_hub[hf_transfer]==0.27.0` (consistent with the already-pinned `torch==2.5.1` and `transformers==4.48.0`)

Several other examples also have unpinned deps (deepfloyd-xl, audiogen-medium, musicgen-*, etc.) but those involve git dependencies or older models where version selection needs maintainer input.