### PR TITLE
Remove config version overrides

### DIFF
--- a/11-embeddings-reranker-classification-tensorrt/BEI-Bert-ner-bert-base-ner-uncased/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/BEI-Bert-ner-bert-base-ner-uncased/config.yaml
@@ -24,6 +24,3 @@ trt_llm:
     max_num_tokens: 16384
   runtime:
     webserver_default_route: /rerank
-  version_overrides:
-    engine_builder_version: null
-    bei_bert_version: 1.8.6.ner

--- a/11-embeddings-reranker-classification-tensorrt/BEI-Bert-tanaos-tanaos-ner-v1/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/BEI-Bert-tanaos-tanaos-ner-v1/config.yaml
@@ -24,6 +24,3 @@ trt_llm:
     max_num_tokens: 16384
   runtime:
     webserver_default_route: /rerank
-  version_overrides:
-    engine_builder_version: null
-    bei_bert_version: 1.8.6.ner

--- a/baseten-inference-stack-v2-templates/gpt-oss-120b/config.yaml
+++ b/baseten-inference-stack-v2-templates/gpt-oss-120b/config.yaml
@@ -60,5 +60,3 @@ trt_llm:
         backend: TRTLLM
     served_model_name: openai/gpt-oss-120b
     tensor_parallel_size: 1
-  version_overrides:
-    v2_llm_version: null

--- a/openai/gpt-oss-120b/config.yaml
+++ b/openai/gpt-oss-120b/config.yaml
@@ -65,5 +65,3 @@ trt_llm:
         backend: TRTLLM
     served_model_name: openai/gpt-oss-120b
     tensor_parallel_size: 1
-  version_overrides:
-    v2_llm_version: null

--- a/openai/gpt-oss-20b/config.yaml
+++ b/openai/gpt-oss-20b/config.yaml
@@ -65,5 +65,3 @@ trt_llm:
         backend: CUTLASS
     served_model_name: openai/gpt-oss-20b
     tensor_parallel_size: 1
-  version_overrides:
-    v2_llm_version: null

--- a/qwen/BEI-qwen-qwen3-embedding-0.6b-fp8/config.yaml
+++ b/qwen/BEI-qwen-qwen3-embedding-0.6b-fp8/config.yaml
@@ -25,6 +25,3 @@ trt_llm:
     quantization_type: fp8
   runtime:
     webserver_default_route: /v1/embeddings
-  version_overrides:
-    bei_version: 0.0.25-b200-dev-v4
-    engine_builder_version: 0.20.0.dev1

--- a/qwen/BEI-qwen-qwen3-embedding-4b-fp8/config.yaml
+++ b/qwen/BEI-qwen-qwen3-embedding-4b-fp8/config.yaml
@@ -23,6 +23,3 @@ trt_llm:
     quantization_type: fp8
   runtime:
     webserver_default_route: /v1/embeddings
-  version_overrides:
-    bei_version: 0.0.23
-    engine_builder_version: 0.18.1.post10.dev1

--- a/qwen/BEI-qwen-qwen3-embedding-8b-fp8/config.yaml
+++ b/qwen/BEI-qwen-qwen3-embedding-8b-fp8/config.yaml
@@ -24,6 +24,3 @@ trt_llm:
     quantization_type: fp8
   runtime:
     webserver_default_route: /v1/embeddings
-  version_overrides:
-    bei_version: 0.0.25-b200-dev-v4
-    engine_builder_version: 0.20.0.dev1

--- a/qwen/BEI-qwen-qwen3-reranker-0.6b-fp8/config.yaml
+++ b/qwen/BEI-qwen-qwen3-reranker-0.6b-fp8/config.yaml
@@ -26,6 +26,3 @@ trt_llm:
     quantization_type: fp8
   runtime:
     webserver_default_route: /predict
-  version_overrides:
-    bei_version: 0.0.25-b200-dev-v4
-    engine_builder_version: 0.20.0.dev1

--- a/qwen/BEI-qwen-qwen3-reranker-4b-fp8/config.yaml
+++ b/qwen/BEI-qwen-qwen3-reranker-4b-fp8/config.yaml
@@ -26,6 +26,3 @@ trt_llm:
     quantization_type: fp8
   runtime:
     webserver_default_route: /predict
-  version_overrides:
-    bei_version: 0.0.23
-    engine_builder_version: 0.18.1.post10.dev1

--- a/qwen/BEI-qwen-qwen3-reranker-8b-fp8/config.yaml
+++ b/qwen/BEI-qwen-qwen3-reranker-8b-fp8/config.yaml
@@ -26,6 +26,3 @@ trt_llm:
     quantization_type: fp8
   runtime:
     webserver_default_route: /predict
-  version_overrides:
-    bei_version: 0.0.25-b200-dev-v4
-    engine_builder_version: 0.20.0.dev1

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp4/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp4/config.yaml
@@ -62,8 +62,6 @@ trt_llm:
         event_buffer_max_size: 1024
       cuda_graph_config:
         enable_padding: true
-  version_overrides:
-    v2_llm_version: trtllm-gpu-1.3.0rc2-6bfe58f1a-d40e7fc8d3
 runtime:
   predict_concurrency: 32
   health_checks:

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp8/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp8/config.yaml
@@ -61,8 +61,6 @@ trt_llm:
         event_buffer_max_size: 1024
       cuda_graph_config:
         enable_padding: true
-  version_overrides:
-    v2_llm_version: trtllm-gpu-1.3.0rc2-6bfe58f1a-d40e7fc8d3
 runtime:
   predict_concurrency: 32
   health_checks:

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/h100-fp8/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/h100-fp8/config.yaml
@@ -50,5 +50,3 @@ trt_llm:
       kv_cache_config:
         enable_block_reuse: true
         free_gpu_memory_fraction: 0.8
-  version_overrides:
-    v2_llm_version: null


### PR DESCRIPTION
## Summary
- remove `trt_llm.version_overrides` blocks from the 14 `config.yaml` files that were using them
- validate the edited YAML files parse cleanly after the removals
- push each affected Truss to the `baseten` remote using `~/venv`