### PR TITLE
Migrate example configs from model_cache to weights (BDN)

### DIFF
--- a/06-high-performance-cached-weights/config.yaml
+++ b/06-high-performance-cached-weights/config.yaml
@@ -15,25 +15,19 @@ requirements:
   - transformers==4.34.0
   - sentencepiece==0.1.99
   - numpy==1.26.4
-# # Configuring the model_cache
+# # Configuring the weights
 #
-# To cache model weights, set the `model_cache` key.
-# The `repo_id` field allows you to specify a Huggingface
-# repo to pull down and cache at build-time, and the `ignore_patterns`
-# field allows you to specify files to ignore. If this is specified, then
-# this repo won't have to be pulled during runtime.
+# To cache model weights, set the `weights` key.
+# The `source` field allows you to specify a Hugging Face
+# repo to mount with BDN, and the `ignore_patterns` field allows you
+# to specify files to ignore.
 #
 # Check out the [guide](https://truss.baseten.co/guides/model-cache) for more info.
-model_cache:
-  - repo_id: "NousResearch/Llama-2-7b-chat-hf"
-    revision: main
+weights:
+  - source: "hf://NousResearch/Llama-2-7b-chat-hf@main"
+    mount_location: "/app/model_cache/llama-2-7b-chat-hf"
     ignore_patterns:
       - "*.bin"
-    use_volume: true
-    volume_folder: "llama-2-7b-chat-hf"
-
-# The remaining config options are again, similar to what you would
-# configure for the model without the weight caching.
 resources:
   cpu: "4"
   memory: 30Gi

--- a/06-high-performance-cached-weights/config.yaml
+++ b/06-high-performance-cached-weights/config.yaml
@@ -25,7 +25,7 @@ requirements:
 # Check out the [guide](https://truss.baseten.co/guides/model-cache) for more info.
 weights:
   - source: "hf://NousResearch/Llama-2-7b-chat-hf@main"
-    mount_location: "/app/model_cache/llama-2-7b-chat-hf"
+    mount_location: "/cache/model/llama-2-7b-chat-hf"
     ignore_patterns:
       - "*.bin"
 resources:

--- a/06-high-performance-cached-weights/config.yaml
+++ b/06-high-performance-cached-weights/config.yaml
@@ -25,7 +25,7 @@ requirements:
 # Check out the [guide](https://truss.baseten.co/guides/model-cache) for more info.
 weights:
   - source: "hf://NousResearch/Llama-2-7b-chat-hf@main"
-    mount_location: "/cache/model/llama-2-7b-chat-hf"
+    mount_location: "/weights/llama-2-7b-chat-hf"
     ignore_patterns:
       - "*.bin"
 resources:

--- a/06-high-performance-cached-weights/model/model.py
+++ b/06-high-performance-cached-weights/model/model.py
@@ -17,7 +17,7 @@ DEFAULT_SYSTEM_PROMPT = "You are a helpful, respectful and honest assistant."
 
 B_INST, E_INST = "[INST]", "[/INST]"
 B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
-CHECKPOINT = "/cache/model/llama-2-7b-chat-hf"
+CHECKPOINT = "/weights/llama-2-7b-chat-hf"
 
 
 def format_prompt(prompt: str, system_prompt: str = DEFAULT_SYSTEM_PROMPT) -> str:

--- a/06-high-performance-cached-weights/model/model.py
+++ b/06-high-performance-cached-weights/model/model.py
@@ -17,7 +17,7 @@ DEFAULT_SYSTEM_PROMPT = "You are a helpful, respectful and honest assistant."
 
 B_INST, E_INST = "[INST]", "[/INST]"
 B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
-CHECKPOINT = "/app/model_cache/llama-2-7b-chat-hf"
+CHECKPOINT = "/cache/model/llama-2-7b-chat-hf"
 
 
 def format_prompt(prompt: str, system_prompt: str = DEFAULT_SYSTEM_PROMPT) -> str:

--- a/07-high-performance-dynamic-batching/config.yaml
+++ b/07-high-performance-dynamic-batching/config.yaml
@@ -15,7 +15,7 @@ requirements:
   - soundfile==0.12.1
 weights:
   - source: "hf://baseten/trtllm-whisper-a10g-large-v2-1@main"
-    mount_location: "/cache/model/trtllm-whisper-a10g-large-v2-1"
+    mount_location: "/weights/trtllm-whisper-a10g-large-v2-1"
 system_packages:
   - python3.10-venv
   - ffmpeg

--- a/07-high-performance-dynamic-batching/config.yaml
+++ b/07-high-performance-dynamic-batching/config.yaml
@@ -15,7 +15,7 @@ requirements:
   - soundfile==0.12.1
 weights:
   - source: "hf://baseten/trtllm-whisper-a10g-large-v2-1@main"
-    mount_location: "/app/model_cache/trtllm-whisper-a10g-large-v2-1"
+    mount_location: "/cache/model/trtllm-whisper-a10g-large-v2-1"
 system_packages:
   - python3.10-venv
   - ffmpeg

--- a/07-high-performance-dynamic-batching/config.yaml
+++ b/07-high-performance-dynamic-batching/config.yaml
@@ -13,11 +13,9 @@ requirements:
   - kaldialign==0.9
   - openai-whisper==20250625
   - soundfile==0.12.1
-model_cache:
-  - repo_id: baseten/trtllm-whisper-a10g-large-v2-1
-    revision: main
-    use_volume: true
-    volume_folder: trtllm-whisper-a10g-large-v2-1
+weights:
+  - source: "hf://baseten/trtllm-whisper-a10g-large-v2-1@main"
+    mount_location: "/app/model_cache/trtllm-whisper-a10g-large-v2-1"
 system_packages:
   - python3.10-venv
   - ffmpeg

--- a/07-high-performance-dynamic-batching/model/model.py
+++ b/07-high-performance-dynamic-batching/model/model.py
@@ -40,7 +40,7 @@ class Model:
         gc.freeze()
 
     def load(self):
-        self._model = WhisperTRTLLM("/app/model_cache/trtllm-whisper-a10g-large-v2-1")
+        self._model = WhisperTRTLLM("/cache/model/trtllm-whisper-a10g-large-v2-1")
         self._batcher = MlBatcher(
             model=self._model,
             max_batch_size=MAX_BATCH_SIZE,

--- a/07-high-performance-dynamic-batching/model/model.py
+++ b/07-high-performance-dynamic-batching/model/model.py
@@ -40,7 +40,7 @@ class Model:
         gc.freeze()
 
     def load(self):
-        self._model = WhisperTRTLLM("/cache/model/trtllm-whisper-a10g-large-v2-1")
+        self._model = WhisperTRTLLM("/weights/trtllm-whisper-a10g-large-v2-1")
         self._batcher = MlBatcher(
             model=self._model,
             max_batch_size=MAX_BATCH_SIZE,

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-modernbert-base-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-modernbert-base-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://Alibaba-NLP/gte-modernbert-base@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-modernbert-base-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-modernbert-base-embedding/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: Alibaba-NLP/gte-modernbert-base
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://Alibaba-NLP/gte-modernbert-base@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-modernbert-base-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-modernbert-base-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://Alibaba-NLP/gte-modernbert-base@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-1.5b-instruct-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-1.5b-instruct-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://Alibaba-NLP/gte-Qwen2-1.5B-instruct@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-1.5b-instruct-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-1.5b-instruct-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://Alibaba-NLP/gte-Qwen2-1.5B-instruct@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-1.5b-instruct-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-1.5b-instruct-embedding/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: Alibaba-NLP/gte-Qwen2-1.5B-instruct
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://Alibaba-NLP/gte-Qwen2-1.5B-instruct@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-7b-instruct-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-7b-instruct-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
 weights:
   - source: "hf://Alibaba-NLP/gte-Qwen2-7B-instruct@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-7b-instruct-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-7b-instruct-embedding/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: Alibaba-NLP/gte-Qwen2-7B-instruct
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://Alibaba-NLP/gte-Qwen2-7B-instruct@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-7b-instruct-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-qwen2-7b-instruct-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
 weights:
   - source: "hf://Alibaba-NLP/gte-Qwen2-7B-instruct@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-reranker-modernbert-base/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-reranker-modernbert-base/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /rerank
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: Alibaba-NLP/gte-reranker-modernbert-base
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://Alibaba-NLP/gte-reranker-modernbert-base@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     query: What is Baseten?

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-reranker-modernbert-base/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-reranker-modernbert-base/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://Alibaba-NLP/gte-reranker-modernbert-base@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-reranker-modernbert-base/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-alibaba-nlp-gte-reranker-modernbert-base/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://Alibaba-NLP/gte-reranker-modernbert-base@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-baai-bge-reranker-large/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-baai-bge-reranker-large/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
 weights:
   - source: "hf://BAAI/bge-reranker-large@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-baai-bge-reranker-large/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-baai-bge-reranker-large/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /rerank
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: BAAI/bge-reranker-large
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://BAAI/bge-reranker-large@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     query: What is Baseten?

--- a/11-embeddings-reranker-classification-tensorrt/TEI-baai-bge-reranker-large/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-baai-bge-reranker-large/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
 weights:
   - source: "hf://BAAI/bge-reranker-large@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-google-embeddinggemma-300m/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-google-embeddinggemma-300m/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://google/embeddinggemma-300m@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-google-embeddinggemma-300m/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-google-embeddinggemma-300m/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: google/embeddinggemma-300m
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://google/embeddinggemma-300m@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-google-embeddinggemma-300m/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-google-embeddinggemma-300m/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://google/embeddinggemma-300m@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-intfloat-multilingual-e5-large-instruct/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-intfloat-multilingual-e5-large-instruct/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://intfloat/multilingual-e5-large-instruct@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-intfloat-multilingual-e5-large-instruct/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-intfloat-multilingual-e5-large-instruct/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://intfloat/multilingual-e5-large-instruct@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-intfloat-multilingual-e5-large-instruct/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-intfloat-multilingual-e5-large-instruct/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: intfloat/multilingual-e5-large-instruct
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://intfloat/multilingual-e5-large-instruct@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-jina-ai-jina-embeddings-v2-base-en/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-jina-ai-jina-embeddings-v2-base-en/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: jinaai/jina-embeddings-v2-base-en
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://jinaai/jina-embeddings-v2-base-en@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-jina-ai-jina-embeddings-v2-base-en/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-jina-ai-jina-embeddings-v2-base-en/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://jinaai/jina-embeddings-v2-base-en@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-jina-ai-jina-embeddings-v2-base-en/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-jina-ai-jina-embeddings-v2-base-en/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://jinaai/jina-embeddings-v2-base-en@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-jinaai-jina-embeddings-v2-base-code/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-jinaai-jina-embeddings-v2-base-code/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://jinaai/jina-embeddings-v2-base-code@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-jinaai-jina-embeddings-v2-base-code/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-jinaai-jina-embeddings-v2-base-code/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://jinaai/jina-embeddings-v2-base-code@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-jinaai-jina-embeddings-v2-base-code/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-jinaai-jina-embeddings-v2-base-code/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: jinaai/jina-embeddings-v2-base-code
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://jinaai/jina-embeddings-v2-base-code@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-mixedbread-ai-mxbai-embed-large-v1-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-mixedbread-ai-mxbai-embed-large-v1-embedding/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: mixedbread-ai/mxbai-embed-large-v1
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://mixedbread-ai/mxbai-embed-large-v1@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-mixedbread-ai-mxbai-embed-large-v1-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-mixedbread-ai-mxbai-embed-large-v1-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://mixedbread-ai/mxbai-embed-large-v1@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-mixedbread-ai-mxbai-embed-large-v1-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-mixedbread-ai-mxbai-embed-large-v1-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://mixedbread-ai/mxbai-embed-large-v1@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v1.5/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v1.5/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://nomic-ai/nomic-embed-text-v1.5@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v1.5/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v1.5/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://nomic-ai/nomic-embed-text-v1.5@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v1.5/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v1.5/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: nomic-ai/nomic-embed-text-v1.5
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://nomic-ai/nomic-embed-text-v1.5@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v2-moe/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v2-moe/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: nomic-ai/nomic-embed-text-v2-moe
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://nomic-ai/nomic-embed-text-v2-moe@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v2-moe/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v2-moe/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://nomic-ai/nomic-embed-text-v2-moe@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v2-moe/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-nomic-ai-nomic-embed-text-v2-moe/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://nomic-ai/nomic-embed-text-v2-moe@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-redis-langcache-embed-v2/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-redis-langcache-embed-v2/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: redis/langcache-embed-v2
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://redis/langcache-embed-v2@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-redis-langcache-embed-v2/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-redis-langcache-embed-v2/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://redis/langcache-embed-v2@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-redis-langcache-embed-v2/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-redis-langcache-embed-v2/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://redis/langcache-embed-v2@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-sentence-transformers-all-minilm-l6-v2-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-sentence-transformers-all-minilm-l6-v2-embedding/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: sentence-transformers/all-MiniLM-L6-v2
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://sentence-transformers/all-MiniLM-L6-v2@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-sentence-transformers-all-minilm-l6-v2-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-sentence-transformers-all-minilm-l6-v2-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
 weights:
   - source: "hf://sentence-transformers/all-MiniLM-L6-v2@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-sentence-transformers-all-minilm-l6-v2-embedding/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-sentence-transformers-all-minilm-l6-v2-embedding/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate"
 weights:
   - source: "hf://sentence-transformers/all-MiniLM-L6-v2@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-taylorai-bge-micro-v2/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-taylorai-bge-micro-v2/config.yaml
@@ -6,18 +6,16 @@ docker_server:
   predict_endpoint: /v1/embeddings
   readiness_endpoint: /health
   server_port: 7997
-  start_command: bash -c "truss-transfer-cli && text-embeddings-router --port 7997
+  start_command: bash -c "text-embeddings-router --port 7997
     --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
-model_cache:
-- ignore_patterns:
-  - '*.pt'
-  - '*.ckpt'
-  - '*.onnx'
-  repo_id: TaylorAI/bge-micro-v2
-  revision: main
-  use_volume: true
-  volume_folder: cached_model
+weights:
+  - source: "hf://TaylorAI/bge-micro-v2@main"
+    mount_location: "/app/model_cache/cached_model"
+    ignore_patterns:
+      - "*.pt"
+      - "*.ckpt"
+      - "*.onnx"
 model_metadata:
   example_model_input:
     encoding_format: float

--- a/11-embeddings-reranker-classification-tensorrt/TEI-taylorai-bge-micro-v2/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-taylorai-bge-micro-v2/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://TaylorAI/bge-micro-v2@main"
-    mount_location: "/app/model_cache/cached_model"
+    mount_location: "/cache/model/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/TEI-taylorai-bge-micro-v2/config.yaml
+++ b/11-embeddings-reranker-classification-tensorrt/TEI-taylorai-bge-micro-v2/config.yaml
@@ -7,11 +7,11 @@ docker_server:
   readiness_endpoint: /health
   server_port: 7997
   start_command: bash -c "text-embeddings-router --port 7997
-    --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests
+    --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests
     1024 --max-batch-tokens 16384 --auto-truncate --tokenization-workers 3"
 weights:
   - source: "hf://TaylorAI/bge-micro-v2@main"
-    mount_location: "/cache/model/cached_model"
+    mount_location: "/weights/cached_model"
     ignore_patterns:
       - "*.pt"
       - "*.ckpt"

--- a/11-embeddings-reranker-classification-tensorrt/templating/generate_templates.py
+++ b/11-embeddings-reranker-classification-tensorrt/templating/generate_templates.py
@@ -24,8 +24,6 @@ from truss.base.trt_llm_config import (
 from truss.base.truss_config import (
     Accelerator,
     AcceleratorSpec,
-    ModelCache,
-    ModelRepo,
     Resources,
     TrussConfig,
 )
@@ -241,19 +239,15 @@ For larger models, we recommend downloading the weights at runtime for faster au
         return TrussConfig(
             base_image=dict(image=docker_image),
             model_metadata=dp.task.model_metadata,
-            model_cache=ModelCache(
-                [
-                    ModelRepo(
-                        revision="main",
-                        repo_id=dp.hf_model_id,
-                        use_volume=True,
-                        volume_folder="cached_model",
-                        ignore_patterns=["*.pt", "*.ckpt", "*.onnx"],
-                    )
-                ]
-            ),
+            weights=[
+                {
+                    "source": f"hf://{dp.hf_model_id}@main",
+                    "mount_location": "/app/model_cache/cached_model",
+                    "ignore_patterns": ["*.pt", "*.ckpt", "*.onnx"],
+                }
+            ],
             docker_server=dict(
-                start_command=f'bash -c "truss-transfer-cli && text-embeddings-router --port 7997 --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests 1024 --max-batch-tokens 16384 --auto-truncate{low_cpu_instructions}"',
+                start_command=f'bash -c "text-embeddings-router --port 7997 --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests 1024 --max-batch-tokens 16384 --auto-truncate{low_cpu_instructions}"',
                 readiness_endpoint="/health",
                 liveness_endpoint="/health",
                 predict_endpoint=predict_endpoint,

--- a/11-embeddings-reranker-classification-tensorrt/templating/generate_templates.py
+++ b/11-embeddings-reranker-classification-tensorrt/templating/generate_templates.py
@@ -242,12 +242,12 @@ For larger models, we recommend downloading the weights at runtime for faster au
             weights=[
                 {
                     "source": f"hf://{dp.hf_model_id}@main",
-                    "mount_location": "/app/model_cache/cached_model",
+                    "mount_location": "/cache/model/cached_model",
                     "ignore_patterns": ["*.pt", "*.ckpt", "*.onnx"],
                 }
             ],
             docker_server=dict(
-                start_command=f'bash -c "text-embeddings-router --port 7997 --model-id /app/model_cache/cached_model --max-client-batch-size 128 --max-concurrent-requests 1024 --max-batch-tokens 16384 --auto-truncate{low_cpu_instructions}"',
+                start_command=f'bash -c "text-embeddings-router --port 7997 --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests 1024 --max-batch-tokens 16384 --auto-truncate{low_cpu_instructions}"',
                 readiness_endpoint="/health",
                 liveness_endpoint="/health",
                 predict_endpoint=predict_endpoint,

--- a/11-embeddings-reranker-classification-tensorrt/templating/generate_templates.py
+++ b/11-embeddings-reranker-classification-tensorrt/templating/generate_templates.py
@@ -242,12 +242,12 @@ For larger models, we recommend downloading the weights at runtime for faster au
             weights=[
                 {
                     "source": f"hf://{dp.hf_model_id}@main",
-                    "mount_location": "/cache/model/cached_model",
+                    "mount_location": "/weights/cached_model",
                     "ignore_patterns": ["*.pt", "*.ckpt", "*.onnx"],
                 }
             ],
             docker_server=dict(
-                start_command=f'bash -c "text-embeddings-router --port 7997 --model-id /cache/model/cached_model --max-client-batch-size 128 --max-concurrent-requests 1024 --max-batch-tokens 16384 --auto-truncate{low_cpu_instructions}"',
+                start_command=f'bash -c "text-embeddings-router --port 7997 --model-id /weights/cached_model --max-client-batch-size 128 --max-concurrent-requests 1024 --max-batch-tokens 16384 --auto-truncate{low_cpu_instructions}"',
                 readiness_endpoint="/health",
                 liveness_endpoint="/health",
                 predict_endpoint=predict_endpoint,

--- a/baseten-inference-stack-v2-templates/glm47/config.yaml
+++ b/baseten-inference-stack-v2-templates/glm47/config.yaml
@@ -22,7 +22,7 @@ model_metadata:
     }
 weights:
   - source: "hf://baseten-admin/glm-4.7-fp4@main"
-    mount_location: "/app/model_cache/glm47"
+    mount_location: "/cache/model/glm47"
     auth_secret_name: "hf_access_token"
 trt_llm:
   build:
@@ -54,4 +54,4 @@ trt_llm:
         enable_padding: false
       enable_iter_perf_stats: true
       autotuner_enabled: false
-      model_path: /app/model_cache/glm47
+      model_path: /cache/model/glm47

--- a/baseten-inference-stack-v2-templates/glm47/config.yaml
+++ b/baseten-inference-stack-v2-templates/glm47/config.yaml
@@ -20,12 +20,10 @@ model_metadata:
       "max_tokens": 2048,
       "temperature": 0.5,
     }
-model_cache:
-  - repo_id: baseten-admin/glm-4.7-fp4
-    revision: main
-    use_volume: true
-    volume_folder: glm47
-    runtime_secret_name: "hf_access_token"
+weights:
+  - source: "hf://baseten-admin/glm-4.7-fp4@main"
+    mount_location: "/app/model_cache/glm47"
+    auth_secret_name: "hf_access_token"
 trt_llm:
   build:
     checkpoint_repository:

--- a/baseten-inference-stack-v2-templates/glm47/config.yaml
+++ b/baseten-inference-stack-v2-templates/glm47/config.yaml
@@ -22,7 +22,7 @@ model_metadata:
     }
 weights:
   - source: "hf://baseten-admin/glm-4.7-fp4@main"
-    mount_location: "/cache/model/glm47"
+    mount_location: "/weights/glm47"
     auth_secret_name: "hf_access_token"
 trt_llm:
   build:
@@ -54,4 +54,4 @@ trt_llm:
         enable_padding: false
       enable_iter_perf_stats: true
       autotuner_enabled: false
-      model_path: /cache/model/glm47
+      model_path: /weights/glm47

--- a/baseten-inference-stack-v2-templates/llama-4-maverick/config.yaml
+++ b/baseten-inference-stack-v2-templates/llama-4-maverick/config.yaml
@@ -22,7 +22,7 @@ model_metadata:
     }
 weights:
   - source: "hf://nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8@main"
-    mount_location: "/cache/model/llama"
+    mount_location: "/weights/llama"
     auth_secret_name: "hf_access_token"
 trt_llm:
   build:
@@ -54,4 +54,4 @@ trt_llm:
       tool_call_parser: pythonic
 
       # model cache
-      model_path: /cache/model/llama
+      model_path: /weights/llama

--- a/baseten-inference-stack-v2-templates/llama-4-maverick/config.yaml
+++ b/baseten-inference-stack-v2-templates/llama-4-maverick/config.yaml
@@ -20,13 +20,10 @@ model_metadata:
       "max_tokens": 2048,
       "temperature": 0.5,
     }
-model_cache:
-  - repo_id: nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8
-    revision: main
-    use_volume: true
-    volume_folder: llama
-    runtime_secret_name: "hf_access_token"
-    kind: "hf"
+weights:
+  - source: "hf://nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8@main"
+    mount_location: "/app/model_cache/llama"
+    auth_secret_name: "hf_access_token"
 trt_llm:
   build:
     checkpoint_repository:

--- a/baseten-inference-stack-v2-templates/llama-4-maverick/config.yaml
+++ b/baseten-inference-stack-v2-templates/llama-4-maverick/config.yaml
@@ -22,7 +22,7 @@ model_metadata:
     }
 weights:
   - source: "hf://nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8@main"
-    mount_location: "/app/model_cache/llama"
+    mount_location: "/cache/model/llama"
     auth_secret_name: "hf_access_token"
 trt_llm:
   build:
@@ -54,4 +54,4 @@ trt_llm:
       tool_call_parser: pythonic
 
       # model cache
-      model_path: /app/model_cache/llama
+      model_path: /cache/model/llama

--- a/binocular/config.yaml
+++ b/binocular/config.yaml
@@ -1,17 +1,18 @@
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.bin'
-  ignore_patterns:
-  - coreml/*
-  repo_id: tiiuae/falcon-7b
-  use_volume: false
-- allow_patterns:
-  - '*.bin'
-  ignore_patterns:
-  - coreml/*
-  repo_id: tiiuae/falcon-7b-instruct
+weights:
+  - source: "hf://tiiuae/falcon-7b@main"
+    mount_location: "/models/falcon-7b"
+    allow_patterns:
+      - "*.bin"
+    ignore_patterns:
+      - "coreml/*"
+  - source: "hf://tiiuae/falcon-7b-instruct@main"
+    mount_location: "/models/falcon-7b-instruct"
+    allow_patterns:
+      - "*.bin"
+    ignore_patterns:
+      - "coreml/*"
 model_name: Binoculars
 python_version: py311
 requirements:

--- a/gemma/gemma-3-27b-it/config.yaml
+++ b/gemma/gemma-3-27b-it/config.yaml
@@ -30,7 +30,7 @@ model_metadata:
   tags:
   - openai-compatible
 docker_server:
-  start_command: "sh -c \"VLLM_USE_V1=1 HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve /app/model_cache/gemma --served-model-name gemma --max-num-seqs 8 --max-model-len 16384 --limit_mm_per_prompt 'image=1' --hf-overrides '{\\\"do_pan_and_scan\\\": true}' --gpu-memory-utilization 0.95\""
+  start_command: "sh -c \"VLLM_USE_V1=1 HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve /cache/model/gemma --served-model-name gemma --max-num-seqs 8 --max-model-len 16384 --limit_mm_per_prompt 'image=1' --hf-overrides '{\\\"do_pan_and_scan\\\": true}' --gpu-memory-utilization 0.95\""
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions
@@ -39,7 +39,7 @@ environment_variables:
   VLLM_LOGGING_LEVEL: INFO
 weights:
   - source: "hf://google/gemma-3-27b-it@005ad3404e59d6023443cb575daa05336842228a"
-    mount_location: "/app/model_cache/gemma"
+    mount_location: "/cache/model/gemma"
 requirements:
 - huggingface_hub
 - hf_transfer

--- a/gemma/gemma-3-27b-it/config.yaml
+++ b/gemma/gemma-3-27b-it/config.yaml
@@ -30,18 +30,16 @@ model_metadata:
   tags:
   - openai-compatible
 docker_server:
-  start_command: "sh -c \"truss-transfer-cli && VLLM_USE_V1=1 HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve /app/model_cache/gemma --served-model-name gemma --max-num-seqs 8 --max-model-len 16384 --limit_mm_per_prompt 'image=1' --hf-overrides '{\\\"do_pan_and_scan\\\": true}' --gpu-memory-utilization 0.95\""
+  start_command: "sh -c \"VLLM_USE_V1=1 HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve /app/model_cache/gemma --served-model-name gemma --max-num-seqs 8 --max-model-len 16384 --limit_mm_per_prompt 'image=1' --hf-overrides '{\\\"do_pan_and_scan\\\": true}' --gpu-memory-utilization 0.95\""
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions
   server_port: 8000
 environment_variables:
   VLLM_LOGGING_LEVEL: INFO
-model_cache:
-  - repo_id: google/gemma-3-27b-it
-    revision: 005ad3404e59d6023443cb575daa05336842228a
-    use_volume: true
-    volume_folder: gemma
+weights:
+  - source: "hf://google/gemma-3-27b-it@005ad3404e59d6023443cb575daa05336842228a"
+    mount_location: "/app/model_cache/gemma"
 requirements:
 - huggingface_hub
 - hf_transfer

--- a/gemma/gemma-3-27b-it/config.yaml
+++ b/gemma/gemma-3-27b-it/config.yaml
@@ -30,7 +30,7 @@ model_metadata:
   tags:
   - openai-compatible
 docker_server:
-  start_command: "sh -c \"VLLM_USE_V1=1 HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve /cache/model/gemma --served-model-name gemma --max-num-seqs 8 --max-model-len 16384 --limit_mm_per_prompt 'image=1' --hf-overrides '{\\\"do_pan_and_scan\\\": true}' --gpu-memory-utilization 0.95\""
+  start_command: "sh -c \"VLLM_USE_V1=1 HF_TOKEN=$(cat /secrets/hf_access_token) vllm serve /weights/gemma --served-model-name gemma --max-num-seqs 8 --max-model-len 16384 --limit_mm_per_prompt 'image=1' --hf-overrides '{\\\"do_pan_and_scan\\\": true}' --gpu-memory-utilization 0.95\""
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions
@@ -39,7 +39,7 @@ environment_variables:
   VLLM_LOGGING_LEVEL: INFO
 weights:
   - source: "hf://google/gemma-3-27b-it@005ad3404e59d6023443cb575daa05336842228a"
-    mount_location: "/cache/model/gemma"
+    mount_location: "/weights/gemma"
 requirements:
 - huggingface_hub
 - hf_transfer

--- a/llama/llama-2-13b-chat/config.yaml
+++ b/llama/llama-2-13b-chat/config.yaml
@@ -2,13 +2,13 @@ description: Generate text from a prompt with this thirteen billion parameter la
   model.
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.model'
-  repo_id: meta-llama/Llama-2-13b-chat-hf
-  use_volume: false
+weights:
+  - source: "hf://meta-llama/Llama-2-13b-chat-hf@main"
+    mount_location: "/models/Llama-2-13b-chat-hf"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.model"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/explore/meta.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png

--- a/llama/llama-2-13b/config.yaml
+++ b/llama/llama-2-13b/config.yaml
@@ -1,12 +1,12 @@
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.model'
-  repo_id: meta-llama/Llama-2-13b-hf
-  use_volume: false
+weights:
+  - source: "hf://meta-llama/Llama-2-13b-hf@main"
+    mount_location: "/models/Llama-2-13b-hf"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.model"
 model_metadata:
   repo_id: meta-llama/Llama-2-13b-hf
 model_name: Llama 13B

--- a/llama/llama-2-70b-chat/config.yaml
+++ b/llama/llama-2-70b-chat/config.yaml
@@ -2,13 +2,13 @@ description: Generate text from a prompt with this seventy billion parameter lan
   model.
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.model'
-  repo_id: meta-llama/Llama-2-70b-chat-hf
-  use_volume: false
+weights:
+  - source: "hf://meta-llama/Llama-2-70b-chat-hf@main"
+    mount_location: "/models/Llama-2-70b-chat-hf"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.model"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/explore/meta.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png

--- a/llama/llama-2-70b/config.yaml
+++ b/llama/llama-2-70b/config.yaml
@@ -1,12 +1,12 @@
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.model'
-  repo_id: meta-llama/Llama-2-70b-hf
-  use_volume: false
+weights:
+  - source: "hf://meta-llama/Llama-2-70b-hf@main"
+    mount_location: "/models/Llama-2-70b-hf"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.model"
 model_metadata:
   repo_id: meta-llama/Llama-2-70b-hf
 model_name: Llama 70B

--- a/llama/llama-2-7b-chat/config.yaml
+++ b/llama/llama-2-7b-chat/config.yaml
@@ -2,13 +2,13 @@ description: Generate text from a prompt with this seven billion parameter langu
   model.
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.model'
-  repo_id: meta-llama/Llama-2-7b-chat-hf
-  use_volume: false
+weights:
+  - source: "hf://meta-llama/Llama-2-7b-chat-hf@main"
+    mount_location: "/models/Llama-2-7b-chat-hf"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.model"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/explore/meta.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/llama.png

--- a/llama/llama-2-7b/config.yaml
+++ b/llama/llama-2-7b/config.yaml
@@ -1,12 +1,12 @@
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.model'
-  repo_id: meta-llama/Llama-2-7b-hf
-  use_volume: false
+weights:
+  - source: "hf://meta-llama/Llama-2-7b-hf@main"
+    mount_location: "/models/Llama-2-7b-hf"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.model"
 model_metadata:
   repo_id: meta-llama/Llama-2-7b-hf
 model_name: Falcon 7B

--- a/llama/llama-3-8b-instruct/config.yaml
+++ b/llama/llama-3-8b-instruct/config.yaml
@@ -8,9 +8,9 @@ model_metadata:
   - text-generation
 model_name: Llama 3 8B Instruct
 python_version: py310
-model_cache:
-  - repo_id: meta-llama/Meta-Llama-3-8B-Instruct
-    use_volume: false
+weights:
+  - source: "hf://meta-llama/Meta-Llama-3-8B-Instruct@main"
+    mount_location: "/models/Meta-Llama-3-8B-Instruct"
 requirements:
   - accelerate
   - einops

--- a/llama/llama-3_1-8b-instruct-sglang/config.yaml
+++ b/llama/llama-3_1-8b-instruct-sglang/config.yaml
@@ -7,9 +7,9 @@ model_metadata:
 requirements:
   - sglang[all]==0.3.0
   - https://github.com/flashinfer-ai/flashinfer/releases/download/v0.1.6/flashinfer-0.1.6+cu121torch2.4-cp311-cp311-linux_x86_64.whl
-model_cache:
-  - repo_id: meta-llama/Llama-3.1-8B-Instruct
-    use_volume: false
+weights:
+  - source: "hf://meta-llama/Llama-3.1-8B-Instruct@main"
+    mount_location: "/models/Llama-3.1-8B-Instruct"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/llama/llama-3_1-8b-instruct/config.yaml
+++ b/llama/llama-3_1-8b-instruct/config.yaml
@@ -6,9 +6,9 @@ model_metadata:
   tensor_parallel: 1
 requirements:
   - vllm==0.5.3post1
-model_cache:
-  - repo_id: meta-llama/Llama-3.1-8B-Instruct
-    use_volume: false
+weights:
+  - source: "hf://meta-llama/Llama-3.1-8B-Instruct@main"
+    mount_location: "/models/Llama-3.1-8B-Instruct"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/metavoice-1b/config.yaml
+++ b/metavoice-1b/config.yaml
@@ -6,18 +6,19 @@ model_metadata:
   example_model_input: '"text to speech models are cool"'
 python_version: py311
 data_dir: data
-model_cache:
-  - repo_id: metavoiceio/metavoice-1B-v0.1
-    use_volume: false
+weights:
+  - source: "hf://metavoiceio/metavoice-1B-v0.1@main"
+    mount_location: "/models/metavoice-1B-v0.1"
     allow_patterns:
       - "*.pt"
-  - repo_id: facebook/multiband-diffusion
+  - source: "hf://facebook/multiband-diffusion@main"
+    mount_location: "/models/multiband-diffusion"
     allow_patterns:
-      - mbd_comp_8.pt
-  - repo_id: facebook/encodec_24khz
+      - "mbd_comp_8.pt"
+  - source: "hf://facebook/encodec_24khz@main"
+    mount_location: "/models/encodec_24khz"
     allow_patterns:
       - "*.safetensors"
-
 requirements_file: ./requirements.txt
 resources:
   accelerator: "A10G"

--- a/minimax/minimax_m2_1/config.yaml
+++ b/minimax/minimax_m2_1/config.yaml
@@ -5,21 +5,19 @@ docker_server:
   predict_endpoint: /v1/chat/completions
   readiness_endpoint: /health_generate
   server_port: 8000
-  start_command: sh -c "truss-transfer-cli && find /app/model_cache/checkpoint -type f -print0 | xargs -0 -P 0 -I {} dd if={} of=/dev/null bs=4M && python3 -m sglang.launch_server --model-path /app/model_cache/checkpoint --tp-size 8 --ep-size 8 --tool-call-parser minimax-m2 --trust-remote-code --host 0.0.0.0 --reasoning-parser minimax --port 8000 --mem-fraction-static 0.85"
+  start_command: sh -c "find /app/model_cache/checkpoint -type f -print0 | xargs -0 -P 0 -I {} dd if={} of=/dev/null bs=4M && python3 -m sglang.launch_server --model-path /app/model_cache/checkpoint --tp-size 8 --ep-size 8 --tool-call-parser minimax-m2 --trust-remote-code --host 0.0.0.0 --reasoning-parser minimax --port 8000 --mem-fraction-static 0.85"
 #environment_variables:
 #  SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN: 1
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.txt'
-  - '*.model'
-  - '*.py'
-  - '*.jinja'
-  repo_id: MiniMaxAI/MiniMax-M2.1
-  revision: 927ea2b64008fe4a1e31a4e107a6b75916b3b44a
-  use_volume: true
-  volume_folder: checkpoint
+weights:
+  - source: "hf://MiniMaxAI/MiniMax-M2.1@927ea2b64008fe4a1e31a4e107a6b75916b3b44a"
+    mount_location: "/app/model_cache/checkpoint"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.txt"
+      - "*.model"
+      - "*.py"
+      - "*.jinja"
 model_metadata:
   example_model_input:
     max_tokens: 4096

--- a/minimax/minimax_m2_1/config.yaml
+++ b/minimax/minimax_m2_1/config.yaml
@@ -5,12 +5,12 @@ docker_server:
   predict_endpoint: /v1/chat/completions
   readiness_endpoint: /health_generate
   server_port: 8000
-  start_command: sh -c "find /cache/model/checkpoint -type f -print0 | xargs -0 -P 0 -I {} dd if={} of=/dev/null bs=4M && python3 -m sglang.launch_server --model-path /cache/model/checkpoint --tp-size 8 --ep-size 8 --tool-call-parser minimax-m2 --trust-remote-code --host 0.0.0.0 --reasoning-parser minimax --port 8000 --mem-fraction-static 0.85"
+  start_command: sh -c "find /weights/checkpoint -type f -print0 | xargs -0 -P 0 -I {} dd if={} of=/dev/null bs=4M && python3 -m sglang.launch_server --model-path /weights/checkpoint --tp-size 8 --ep-size 8 --tool-call-parser minimax-m2 --trust-remote-code --host 0.0.0.0 --reasoning-parser minimax --port 8000 --mem-fraction-static 0.85"
 #environment_variables:
 #  SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN: 1
 weights:
   - source: "hf://MiniMaxAI/MiniMax-M2.1@927ea2b64008fe4a1e31a4e107a6b75916b3b44a"
-    mount_location: "/cache/model/checkpoint"
+    mount_location: "/weights/checkpoint"
     allow_patterns:
       - "*.json"
       - "*.safetensors"

--- a/minimax/minimax_m2_1/config.yaml
+++ b/minimax/minimax_m2_1/config.yaml
@@ -5,12 +5,12 @@ docker_server:
   predict_endpoint: /v1/chat/completions
   readiness_endpoint: /health_generate
   server_port: 8000
-  start_command: sh -c "find /app/model_cache/checkpoint -type f -print0 | xargs -0 -P 0 -I {} dd if={} of=/dev/null bs=4M && python3 -m sglang.launch_server --model-path /app/model_cache/checkpoint --tp-size 8 --ep-size 8 --tool-call-parser minimax-m2 --trust-remote-code --host 0.0.0.0 --reasoning-parser minimax --port 8000 --mem-fraction-static 0.85"
+  start_command: sh -c "find /cache/model/checkpoint -type f -print0 | xargs -0 -P 0 -I {} dd if={} of=/dev/null bs=4M && python3 -m sglang.launch_server --model-path /cache/model/checkpoint --tp-size 8 --ep-size 8 --tool-call-parser minimax-m2 --trust-remote-code --host 0.0.0.0 --reasoning-parser minimax --port 8000 --mem-fraction-static 0.85"
 #environment_variables:
 #  SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN: 1
 weights:
   - source: "hf://MiniMaxAI/MiniMax-M2.1@927ea2b64008fe4a1e31a4e107a6b75916b3b44a"
-    mount_location: "/app/model_cache/checkpoint"
+    mount_location: "/cache/model/checkpoint"
     allow_patterns:
       - "*.json"
       - "*.safetensors"

--- a/mistral/mistral-7b-chat/config.yaml
+++ b/mistral/mistral-7b-chat/config.yaml
@@ -1,13 +1,13 @@
 description: Mistral 7B, optimized for chat! Compatible with OpenAI Client
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.model'
-  use_volume: false
-  repo_id: mistralai/Mistral-7B-Instruct-v0.1
+weights:
+  - source: "hf://mistralai/Mistral-7B-Instruct-v0.1@main"
+    mount_location: "/models/Mistral-7B-Instruct-v0.1"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.model"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/explore/mistral_logo.png
   cover_image_url: https://cdn.baseten.co/production/static/explore/mistral.png

--- a/mistral/mistral-7b-instruct/config.yaml
+++ b/mistral/mistral-7b-instruct/config.yaml
@@ -1,13 +1,13 @@
 description: Generate text with an instruction-tuned version of Mistral 7B.
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.safetensors'
-  - '*.model'
-  repo_id: mistralai/Mistral-7B-Instruct-v0.2
-  use_volume: false
+weights:
+  - source: "hf://mistralai/Mistral-7B-Instruct-v0.2@main"
+    mount_location: "/models/Mistral-7B-Instruct-v0.2"
+    allow_patterns:
+      - "*.json"
+      - "*.safetensors"
+      - "*.model"
 model_metadata:
   repo_id: mistralai/Mistral-7B-Instruct-v0.2
   avatar_url: https://cdn.baseten.co/production/static/explore/mistral_logo.png

--- a/mistral/mistral-7b-instruct/model/model.py
+++ b/mistral/mistral-7b-instruct/model/model.py
@@ -17,15 +17,16 @@ class Model:
         self._hf_access_token = kwargs["secrets"]["hf_access_token"]
 
     def load(self):
+        model_path = self._config["weights"][0]["mount_location"]
         self.model = AutoModelForCausalLM.from_pretrained(
-            self._config["model_cache"][0]["repo_id"],
+            model_path,
             torch_dtype=torch.float16,
             device_map="auto",
             token=self._hf_access_token,
         )
 
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self._config["model_cache"][0]["repo_id"],
+            model_path,
             device_map="auto",
             torch_dtype=torch.float16,
             token=self._hf_access_token,

--- a/model_cach_gcs/config.yaml
+++ b/model_cach_gcs/config.yaml
@@ -12,5 +12,5 @@ build:
 secrets: { gcs-service-account-jsn: null } # null is encouraged, as this will automatically use the one provided by baseten.co
 weights:
   - source: "gs://llama-3-2-1b-instruct/"
-    mount_location: "/app/model_cache/llama"
+    mount_location: "/cache/model/llama"
     auth_secret_name: "gcs-service-account-jsn"

--- a/model_cach_gcs/config.yaml
+++ b/model_cach_gcs/config.yaml
@@ -12,5 +12,5 @@ build:
 secrets: { gcs-service-account-jsn: null } # null is encouraged, as this will automatically use the one provided by baseten.co
 weights:
   - source: "gs://llama-3-2-1b-instruct/"
-    mount_location: "/cache/model/llama"
+    mount_location: "/weights/llama"
     auth_secret_name: "gcs-service-account-jsn"

--- a/model_cach_gcs/config.yaml
+++ b/model_cach_gcs/config.yaml
@@ -10,12 +10,7 @@ build:
   secret_to_path_mapping:
     gcs-service-account-jsn: /secrets/gcs-service-account-jsn
 secrets: { gcs-service-account-jsn: null } # null is encouraged, as this will automatically use the one provided by baseten.co
-model_cache:
-  # this is a simple private bucket, uploaded llama-3-2, as is from huggingface.
-  # The repo contains e.g. gs://llama-3-2-1b-instruct/config.json / gs://llama-3-2-1b-instruct/model.safetensors
-  - repo_id: gs://llama-3-2-1b-instruct/
-    revision: main
-    use_volume: true
-    volume_folder: llama
-    runtime_secret_name: "gcs-service-account-jsn"
-    kind: "gcs"
+weights:
+  - source: "gs://llama-3-2-1b-instruct/"
+    mount_location: "/app/model_cache/llama"
+    auth_secret_name: "gcs-service-account-jsn"

--- a/model_cach_gcs/model/model.py
+++ b/model_cach_gcs/model/model.py
@@ -14,13 +14,13 @@ class Model:
         # work that does not require the download may be done beforehand
         # important to collect the download before using any incomplete data
         self._lazy_data_resolver.block_until_download_complete()
-        # after the call, you may use the /cache/model directory and the contents
+        # after the call, you may use the /weights directory and the contents
         # torch.load(
-        #     "/cache/model/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors",
+        #     "/weights/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors",
         #     weights_only=True
         # )
         self.tensor_size = (
-            pathlib.Path("/cache/model/llama/model.safetensors").stat().st_size
+            pathlib.Path("/weights/llama/model.safetensors").stat().st_size
         )
         print(
             "Model loaded successfully with size of {} bytes".format(self.tensor_size)

--- a/model_cach_gcs/model/model.py
+++ b/model_cach_gcs/model/model.py
@@ -14,13 +14,13 @@ class Model:
         # work that does not require the download may be done beforehand
         # important to collect the download before using any incomplete data
         self._lazy_data_resolver.block_until_download_complete()
-        # after the call, you may use the /app/model_cache directory and the contents
+        # after the call, you may use the /cache/model directory and the contents
         # torch.load(
-        #     "/app/model_cache/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors",
+        #     "/cache/model/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors",
         #     weights_only=True
         # )
         self.tensor_size = (
-            pathlib.Path("/app/model_cache/llama/model.safetensors").stat().st_size
+            pathlib.Path("/cache/model/llama/model.safetensors").stat().st_size
         )
         print(
             "Model loaded successfully with size of {} bytes".format(self.tensor_size)

--- a/model_cache/config.yaml
+++ b/model_cache/config.yaml
@@ -7,23 +7,17 @@ resources:
   memory: 8Gi
   use_gpu: false
 secrets: { hf_access_token: null } # null is encouraged, as this will automatically use the one provided by baseten.co
-model_cache:
-  - repo_id: madebyollin/sdxl-vae-fp16-fix
-    revision: 207b116dae70ace3637169f1ddd2434b91b3a8cd
-    use_volume: true
-    volume_folder: sdxl-vae-fp16
+weights:
+  - source: "hf://madebyollin/sdxl-vae-fp16-fix@207b116dae70ace3637169f1ddd2434b91b3a8cd"
+    mount_location: "/app/model_cache/sdxl-vae-fp16"
+    auth_secret_name: "hf_access_token"
     allow_patterns:
-      - config.json
-      - diffusion_pytorch_model.safetensors
-    runtime_secret_name: hf_access_token
-    kind: "hf"
-  - repo_id: stabilityai/stable-diffusion-xl-base-1.0
-    revision: 462165984030d82259a11f4367a4eed129e94a7b
-    use_volume: true
-    volume_folder: stable-diffusion-xl-base
+      - "config.json"
+      - "diffusion_pytorch_model.safetensors"
+  - source: "hf://stabilityai/stable-diffusion-xl-base-1.0@462165984030d82259a11f4367a4eed129e94a7b"
+    mount_location: "/app/model_cache/stable-diffusion-xl-base"
+    auth_secret_name: "hf_access_token"
     allow_patterns:
       - "*.json"
       - "*.fp16.safetensors"
-      - sd_xl_base_1.0.safetensors
-    runtime_secret_name: hf_access_token
-    kind: "hf"
+      - "sd_xl_base_1.0.safetensors"

--- a/model_cache/config.yaml
+++ b/model_cache/config.yaml
@@ -9,13 +9,13 @@ resources:
 secrets: { hf_access_token: null } # null is encouraged, as this will automatically use the one provided by baseten.co
 weights:
   - source: "hf://madebyollin/sdxl-vae-fp16-fix@207b116dae70ace3637169f1ddd2434b91b3a8cd"
-    mount_location: "/app/model_cache/sdxl-vae-fp16"
+    mount_location: "/cache/model/sdxl-vae-fp16"
     auth_secret_name: "hf_access_token"
     allow_patterns:
       - "config.json"
       - "diffusion_pytorch_model.safetensors"
   - source: "hf://stabilityai/stable-diffusion-xl-base-1.0@462165984030d82259a11f4367a4eed129e94a7b"
-    mount_location: "/app/model_cache/stable-diffusion-xl-base"
+    mount_location: "/cache/model/stable-diffusion-xl-base"
     auth_secret_name: "hf_access_token"
     allow_patterns:
       - "*.json"

--- a/model_cache/config.yaml
+++ b/model_cache/config.yaml
@@ -9,13 +9,13 @@ resources:
 secrets: { hf_access_token: null } # null is encouraged, as this will automatically use the one provided by baseten.co
 weights:
   - source: "hf://madebyollin/sdxl-vae-fp16-fix@207b116dae70ace3637169f1ddd2434b91b3a8cd"
-    mount_location: "/cache/model/sdxl-vae-fp16"
+    mount_location: "/weights/sdxl-vae-fp16"
     auth_secret_name: "hf_access_token"
     allow_patterns:
       - "config.json"
       - "diffusion_pytorch_model.safetensors"
   - source: "hf://stabilityai/stable-diffusion-xl-base-1.0@462165984030d82259a11f4367a4eed129e94a7b"
-    mount_location: "/cache/model/stable-diffusion-xl-base"
+    mount_location: "/weights/stable-diffusion-xl-base"
     auth_secret_name: "hf_access_token"
     allow_patterns:
       - "*.json"

--- a/model_cache/config.yaml
+++ b/model_cache/config.yaml
@@ -1,4 +1,4 @@
-model_name: Hello Model Cache Qwen
+model_name: Hello Weights SDXL
 python_version: py311
 requirements: ["torch"]
 resources:

--- a/model_cache/model/model.py
+++ b/model_cache/model/model.py
@@ -17,14 +17,14 @@ class Model:
         random_vector = torch.randn(1000)
         # important to collect the download before using any incomplete data
         self._lazy_data_resolver.block_until_download_complete()
-        # after the call, you may use the /cache/model directory and the contents
+        # after the call, you may use the /weights directory and the contents
         # torch.load(
-        #     "/cache/model/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors",
+        #     "/weights/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors",
         #     weights_only=True
         # )
         self.tensor_size = (
             pathlib.Path(
-                "/cache/model/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors"
+                "/weights/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors"
             )
             .stat()
             .st_size

--- a/model_cache/model/model.py
+++ b/model_cache/model/model.py
@@ -17,14 +17,14 @@ class Model:
         random_vector = torch.randn(1000)
         # important to collect the download before using any incomplete data
         self._lazy_data_resolver.block_until_download_complete()
-        # after the call, you may use the /app/model_cache directory and the contents
+        # after the call, you may use the /cache/model directory and the contents
         # torch.load(
-        #     "/app/model_cache/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors",
+        #     "/cache/model/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors",
         #     weights_only=True
         # )
         self.tensor_size = (
             pathlib.Path(
-                "/app/model_cache/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors"
+                "/cache/model/stable-diffusion-xl-base/vae_1_0/diffusion_pytorch_model.fp16.safetensors"
             )
             .stat()
             .st_size

--- a/nemotron/Llama-3-1-Nemotron-Nano-VL-8B-V1/config.yaml
+++ b/nemotron/Llama-3-1-Nemotron-Nano-VL-8B-V1/config.yaml
@@ -28,7 +28,7 @@ requirements:
 python_version: py312
 weights:
   - source: "hf://nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1@main"
-    mount_location: "/cache/model/llama-3-1-nemotron-nano-vl-8b-v1"
+    mount_location: "/weights/llama-3-1-nemotron-nano-vl-8b-v1"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/nemotron/Llama-3-1-Nemotron-Nano-VL-8B-V1/config.yaml
+++ b/nemotron/Llama-3-1-Nemotron-Nano-VL-8B-V1/config.yaml
@@ -26,11 +26,9 @@ requirements:
   - open-clip-torch
   - pillow
 python_version: py312
-model_cache:
-  - repo_id: nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1
-    revision: main
-    use_volume: true
-    volume_folder: "llama-3-1-nemotron-nano-vl-8b-v1"
+weights:
+  - source: "hf://nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1@main"
+    mount_location: "/app/model_cache/llama-3-1-nemotron-nano-vl-8b-v1"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/nemotron/Llama-3-1-Nemotron-Nano-VL-8B-V1/config.yaml
+++ b/nemotron/Llama-3-1-Nemotron-Nano-VL-8B-V1/config.yaml
@@ -28,7 +28,7 @@ requirements:
 python_version: py312
 weights:
   - source: "hf://nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1@main"
-    mount_location: "/app/model_cache/llama-3-1-nemotron-nano-vl-8b-v1"
+    mount_location: "/cache/model/llama-3-1-nemotron-nano-vl-8b-v1"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/nemotron/Nemotron-Nano-12B-v2-VL-BF16/config.yaml
+++ b/nemotron/Nemotron-Nano-12B-v2-VL-BF16/config.yaml
@@ -23,11 +23,9 @@ requirements:
   - open-clip-torch
   - pillow
 python_version: py312
-model_cache:
-  - repo_id: nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
-    revision: main
-    use_volume: true
-    volume_folder: "nvidia-nemotron-nano-12b-v2-vl-bf16"
+weights:
+  - source: "hf://nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16@main"
+    mount_location: "/app/model_cache/nvidia-nemotron-nano-12b-v2-vl-bf16"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/nemotron/Nemotron-Nano-12B-v2-VL-BF16/config.yaml
+++ b/nemotron/Nemotron-Nano-12B-v2-VL-BF16/config.yaml
@@ -25,7 +25,7 @@ requirements:
 python_version: py312
 weights:
   - source: "hf://nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16@main"
-    mount_location: "/cache/model/nvidia-nemotron-nano-12b-v2-vl-bf16"
+    mount_location: "/weights/nvidia-nemotron-nano-12b-v2-vl-bf16"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/nemotron/Nemotron-Nano-12B-v2-VL-BF16/config.yaml
+++ b/nemotron/Nemotron-Nano-12B-v2-VL-BF16/config.yaml
@@ -25,7 +25,7 @@ requirements:
 python_version: py312
 weights:
   - source: "hf://nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16@main"
-    mount_location: "/app/model_cache/nvidia-nemotron-nano-12b-v2-vl-bf16"
+    mount_location: "/cache/model/nvidia-nemotron-nano-12b-v2-vl-bf16"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/nous-capybara/nous-capybara-34b-openai/config.yaml
+++ b/nous-capybara/nous-capybara-34b-openai/config.yaml
@@ -1,11 +1,11 @@
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.bin'
-  repo_id: NousResearch/Nous-Capybara-34B
-  use_volume: false
+weights:
+  - source: "hf://NousResearch/Nous-Capybara-34B@main"
+    mount_location: "/models/Nous-Capybara-34B"
+    allow_patterns:
+      - "*.json"
+      - "*.bin"
 model_name: Nous Capybara 34B OpenAI
 python_version: py310
 requirements:

--- a/openai/gpt-oss-120b/config.yaml
+++ b/openai/gpt-oss-120b/config.yaml
@@ -22,11 +22,9 @@ resources:
   cpu: '1'
   memory: 10Gi
   use_gpu: true
-model_cache:
-  - repo_id: openai/gpt-oss-120b
-    revision: refs/pr/35
-    use_volume: true
-    volume_folder: trt_model
+weights:
+  - source: "hf://openai/gpt-oss-120b@refs/pr/35"
+    mount_location: "/app/model_cache/trt_model"
 trt_llm:
   build:
     checkpoint_repository:

--- a/openai/gpt-oss-120b/config.yaml
+++ b/openai/gpt-oss-120b/config.yaml
@@ -24,7 +24,7 @@ resources:
   use_gpu: true
 weights:
   - source: "hf://openai/gpt-oss-120b@refs/pr/35"
-    mount_location: "/cache/model/trt_model"
+    mount_location: "/weights/trt_model"
 trt_llm:
   build:
     checkpoint_repository:
@@ -38,7 +38,7 @@ trt_llm:
     max_num_tokens: 8192
     max_seq_len: 131072
     patch_kwargs:
-      model_path: /cache/model/trt_model
+      model_path: /weights/trt_model
       chat_processor: harmony
       moe_expert_parallel_size: 1
       backend: pytorch

--- a/openai/gpt-oss-120b/config.yaml
+++ b/openai/gpt-oss-120b/config.yaml
@@ -24,7 +24,7 @@ resources:
   use_gpu: true
 weights:
   - source: "hf://openai/gpt-oss-120b@refs/pr/35"
-    mount_location: "/app/model_cache/trt_model"
+    mount_location: "/cache/model/trt_model"
 trt_llm:
   build:
     checkpoint_repository:
@@ -38,7 +38,7 @@ trt_llm:
     max_num_tokens: 8192
     max_seq_len: 131072
     patch_kwargs:
-      model_path: /app/model_cache/trt_model
+      model_path: /cache/model/trt_model
       chat_processor: harmony
       moe_expert_parallel_size: 1
       backend: pytorch

--- a/openai/gpt-oss-20b/config.yaml
+++ b/openai/gpt-oss-20b/config.yaml
@@ -24,7 +24,7 @@ resources:
   use_gpu: true
 weights:
   - source: "hf://openai/gpt-oss-20b@refs/pr/36"
-    mount_location: "/app/model_cache/trt_model"
+    mount_location: "/cache/model/trt_model"
 trt_llm:
   build:
     checkpoint_repository:
@@ -38,7 +38,7 @@ trt_llm:
     max_num_tokens: 8192
     max_seq_len: 131072
     patch_kwargs:
-      model_path: /app/model_cache/trt_model
+      model_path: /cache/model/trt_model
       chat_processor: harmony
       moe_expert_parallel_size: 1
       backend: pytorch

--- a/openai/gpt-oss-20b/config.yaml
+++ b/openai/gpt-oss-20b/config.yaml
@@ -24,7 +24,7 @@ resources:
   use_gpu: true
 weights:
   - source: "hf://openai/gpt-oss-20b@refs/pr/36"
-    mount_location: "/cache/model/trt_model"
+    mount_location: "/weights/trt_model"
 trt_llm:
   build:
     checkpoint_repository:
@@ -38,7 +38,7 @@ trt_llm:
     max_num_tokens: 8192
     max_seq_len: 131072
     patch_kwargs:
-      model_path: /cache/model/trt_model
+      model_path: /weights/trt_model
       chat_processor: harmony
       moe_expert_parallel_size: 1
       backend: pytorch

--- a/openai/gpt-oss-20b/config.yaml
+++ b/openai/gpt-oss-20b/config.yaml
@@ -22,11 +22,9 @@ resources:
   cpu: '1'
   memory: 10Gi
   use_gpu: true
-model_cache:
-  - repo_id: openai/gpt-oss-20b
-    revision: refs/pr/36
-    use_volume: true
-    volume_folder: trt_model
+weights:
+  - source: "hf://openai/gpt-oss-20b@refs/pr/36"
+    mount_location: "/app/model_cache/trt_model"
 trt_llm:
   build:
     checkpoint_repository:

--- a/playground-v2-aesthetic/config.yaml
+++ b/playground-v2-aesthetic/config.yaml
@@ -1,13 +1,13 @@
 description: Generate original images from text prompts.
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.txt'
-  - '*.fp16.safetensors'
-  repo_id: playgroundai/playground-v2-1024px-aesthetic
-  use_volume: false
+weights:
+  - source: "hf://playgroundai/playground-v2-1024px-aesthetic@main"
+    mount_location: "/models/playground-v2-1024px-aesthetic"
+    allow_patterns:
+      - "*.json"
+      - "*.txt"
+      - "*.fp16.safetensors"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/playground-logo.jpeg
   cover_image_url: https://cdn.baseten.co/production/static/playground-v2.png

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp8/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp8/config.yaml
@@ -22,7 +22,7 @@ environment_variables:
   TRTLLM_ENABLE_PDL: 1
 weights:
   - source: "hf://Qwen/Qwen3-235B-A22B-Instruct-2507-FP8@e156cb4efae43fbee1a1ab073f946a1377e6b969"
-    mount_location: "/app/model_cache/qwen3_fp8"
+    mount_location: "/cache/model/qwen3_fp8"
 trt_llm:
   build:
     checkpoint_repository:
@@ -38,7 +38,7 @@ trt_llm:
     tensor_parallel_size: 4
     served_model_name: Qwen/Qwen3-235B-A22B-Instruct-2507
     patch_kwargs:
-      model_path: /app/model_cache/qwen3_fp8
+      model_path: /cache/model/qwen3_fp8
       backend: pytorch
       max_beam_width: 1
       max_input_len: 32768

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp8/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp8/config.yaml
@@ -20,11 +20,9 @@ resources:
 environment_variables:
   BAD_TOKEN_ID_SEQ_CHECK_ENABLED: 1
   TRTLLM_ENABLE_PDL: 1
-model_cache:
-  - repo_id: Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
-    revision: e156cb4efae43fbee1a1ab073f946a1377e6b969
-    use_volume: true
-    volume_folder: qwen3_fp8
+weights:
+  - source: "hf://Qwen/Qwen3-235B-A22B-Instruct-2507-FP8@e156cb4efae43fbee1a1ab073f946a1377e6b969"
+    mount_location: "/app/model_cache/qwen3_fp8"
 trt_llm:
   build:
     checkpoint_repository:

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp8/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/b200-fp8/config.yaml
@@ -22,7 +22,7 @@ environment_variables:
   TRTLLM_ENABLE_PDL: 1
 weights:
   - source: "hf://Qwen/Qwen3-235B-A22B-Instruct-2507-FP8@e156cb4efae43fbee1a1ab073f946a1377e6b969"
-    mount_location: "/cache/model/qwen3_fp8"
+    mount_location: "/weights/qwen3_fp8"
 trt_llm:
   build:
     checkpoint_repository:
@@ -38,7 +38,7 @@ trt_llm:
     tensor_parallel_size: 4
     served_model_name: Qwen/Qwen3-235B-A22B-Instruct-2507
     patch_kwargs:
-      model_path: /cache/model/qwen3_fp8
+      model_path: /weights/qwen3_fp8
       backend: pytorch
       max_beam_width: 1
       max_input_len: 32768

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/h100-fp8/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/h100-fp8/config.yaml
@@ -15,7 +15,7 @@ model_metadata:
 model_name: Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
 weights:
   - source: "hf://Qwen/Qwen3-235B-A22B-Instruct-2507-FP8@main"
-    mount_location: "/app/model_cache/trt_model"
+    mount_location: "/cache/model/trt_model"
 resources:
   accelerator: H100:8
   cpu: "1"
@@ -37,7 +37,7 @@ trt_llm:
     tensor_parallel_size: 8
     patch_kwargs:
       disable_overlap_scheduler: True
-      model_path: /app/model_cache/trt_model
+      model_path: /cache/model/trt_model
       moe_expert_parallel_size: 8
       cuda_graph_config:
         enable_padding: true

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/h100-fp8/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/h100-fp8/config.yaml
@@ -15,7 +15,7 @@ model_metadata:
 model_name: Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
 weights:
   - source: "hf://Qwen/Qwen3-235B-A22B-Instruct-2507-FP8@main"
-    mount_location: "/cache/model/trt_model"
+    mount_location: "/weights/trt_model"
 resources:
   accelerator: H100:8
   cpu: "1"
@@ -37,7 +37,7 @@ trt_llm:
     tensor_parallel_size: 8
     patch_kwargs:
       disable_overlap_scheduler: True
-      model_path: /cache/model/trt_model
+      model_path: /weights/trt_model
       moe_expert_parallel_size: 8
       cuda_graph_config:
         enable_padding: true

--- a/qwen/qwen-3-235B-A22B-instruct-2507-trt/h100-fp8/config.yaml
+++ b/qwen/qwen-3-235B-A22B-instruct-2507-trt/h100-fp8/config.yaml
@@ -13,11 +13,9 @@ model_metadata:
     - openai-compatible
   repo_id: Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
 model_name: Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
-model_cache:
-  - repo_id: Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
-    use_volume: true
-    revision: main
-    volume_folder: trt_model
+weights:
+  - source: "hf://Qwen/Qwen3-235B-A22B-Instruct-2507-FP8@main"
+    mount_location: "/app/model_cache/trt_model"
 resources:
   accelerator: H100:8
   cpu: "1"

--- a/qwen/qwen-3-235B-sglang/config.yaml
+++ b/qwen/qwen-3-235B-sglang/config.yaml
@@ -16,12 +16,12 @@ base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
 weights:
   - source: "hf://Qwen/Qwen3-235B-A22B-FP8@57c8978fa7d601431cfd6750dd7355b5cdfa5a18"
-    mount_location: "/cache/model/qwen3"
+    mount_location: "/weights/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "python3 -m sglang.launch_server --model-path /cache/model/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-235B-A22B --tp 4 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /weights/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-235B-A22B --tp 4 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-235B-sglang/config.yaml
+++ b/qwen/qwen-3-235B-sglang/config.yaml
@@ -16,12 +16,12 @@ base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
 weights:
   - source: "hf://Qwen/Qwen3-235B-A22B-FP8@57c8978fa7d601431cfd6750dd7355b5cdfa5a18"
-    mount_location: "/app/model_cache/qwen3"
+    mount_location: "/cache/model/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-235B-A22B --tp 4 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /cache/model/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-235B-A22B --tp 4 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-235B-sglang/config.yaml
+++ b/qwen/qwen-3-235B-sglang/config.yaml
@@ -14,16 +14,14 @@ model_metadata:
 model_name: Qwen 3 235B SGLang
 base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
-model_cache:
-  - repo_id: Qwen/Qwen3-235B-A22B-FP8
-    revision: 57c8978fa7d601431cfd6750dd7355b5cdfa5a18
-    use_volume: true
-    volume_folder: "qwen3"
+weights:
+  - source: "hf://Qwen/Qwen3-235B-A22B-FP8@57c8978fa7d601431cfd6750dd7355b5cdfa5a18"
+    mount_location: "/app/model_cache/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "truss-transfer-cli && python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-235B-A22B --tp 4 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-235B-A22B --tp 4 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-30B-A3-coder/config.yaml
+++ b/qwen/qwen-3-30B-A3-coder/config.yaml
@@ -14,16 +14,14 @@ model_metadata:
 model_name: Qwen 3 Coder
 base_image:
   image: lmsysorg/sglang:v0.4.10.post2-cu126
-model_cache:
-  - repo_id: Qwen/Qwen3-Coder-30B-A3B-Instruct
-    revision: main
-    use_volume: true
-    volume_folder: "qwen3-coder"
+weights:
+  - source: "hf://Qwen/Qwen3-Coder-30B-A3B-Instruct@main"
+    mount_location: "/app/model_cache/qwen3-coder"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "truss-transfer-cli && python3 -m sglang.launch_server --model-path /app/model_cache/qwen3-coder --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-Coder-30B-A3B-Instruct --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /app/model_cache/qwen3-coder --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-Coder-30B-A3B-Instruct --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-30B-A3-coder/config.yaml
+++ b/qwen/qwen-3-30B-A3-coder/config.yaml
@@ -16,12 +16,12 @@ base_image:
   image: lmsysorg/sglang:v0.4.10.post2-cu126
 weights:
   - source: "hf://Qwen/Qwen3-Coder-30B-A3B-Instruct@main"
-    mount_location: "/app/model_cache/qwen3-coder"
+    mount_location: "/cache/model/qwen3-coder"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "python3 -m sglang.launch_server --model-path /app/model_cache/qwen3-coder --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-Coder-30B-A3B-Instruct --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /cache/model/qwen3-coder --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-Coder-30B-A3B-Instruct --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-30B-A3-coder/config.yaml
+++ b/qwen/qwen-3-30B-A3-coder/config.yaml
@@ -16,12 +16,12 @@ base_image:
   image: lmsysorg/sglang:v0.4.10.post2-cu126
 weights:
   - source: "hf://Qwen/Qwen3-Coder-30B-A3B-Instruct@main"
-    mount_location: "/cache/model/qwen3-coder"
+    mount_location: "/weights/qwen3-coder"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "python3 -m sglang.launch_server --model-path /cache/model/qwen3-coder --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-Coder-30B-A3B-Instruct --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /weights/qwen3-coder --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-Coder-30B-A3B-Instruct --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-30B-A3-sglang/config.yaml
+++ b/qwen/qwen-3-30B-A3-sglang/config.yaml
@@ -18,12 +18,12 @@ base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
 weights:
   - source: "hf://Qwen/Qwen3-30B-A3B-FP8@2daf1706ac267bae18c90a217a060817c0cebb66"
-    mount_location: "/app/model_cache/qwen3"
+    mount_location: "/cache/model/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-30B-A3B --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /cache/model/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-30B-A3B --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-30B-A3-sglang/config.yaml
+++ b/qwen/qwen-3-30B-A3-sglang/config.yaml
@@ -18,12 +18,12 @@ base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
 weights:
   - source: "hf://Qwen/Qwen3-30B-A3B-FP8@2daf1706ac267bae18c90a217a060817c0cebb66"
-    mount_location: "/cache/model/qwen3"
+    mount_location: "/weights/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "python3 -m sglang.launch_server --model-path /cache/model/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-30B-A3B --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /weights/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-30B-A3B --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-30B-A3-sglang/config.yaml
+++ b/qwen/qwen-3-30B-A3-sglang/config.yaml
@@ -16,16 +16,14 @@ environment_variables:
   hf_access_token: null
 base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
-model_cache:
-  - repo_id: Qwen/Qwen3-30B-A3B-FP8
-    revision: 2daf1706ac267bae18c90a217a060817c0cebb66
-    use_volume: true
-    volume_folder: "qwen3"
+weights:
+  - source: "hf://Qwen/Qwen3-30B-A3B-FP8@2daf1706ac267bae18c90a217a060817c0cebb66"
+    mount_location: "/app/model_cache/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "truss-transfer-cli && python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-30B-A3B --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-30B-A3B --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-32B-sglang/config.yaml
+++ b/qwen/qwen-3-32B-sglang/config.yaml
@@ -16,12 +16,12 @@ base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
 weights:
   - source: "hf://Qwen/Qwen3-32B-FP8@37f3f67a7a82b002377985796c57f4321b85fb9a"
-    mount_location: "/app/model_cache/qwen3"
+    mount_location: "/cache/model/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-32B --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /cache/model/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-32B --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-32B-sglang/config.yaml
+++ b/qwen/qwen-3-32B-sglang/config.yaml
@@ -16,12 +16,12 @@ base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
 weights:
   - source: "hf://Qwen/Qwen3-32B-FP8@37f3f67a7a82b002377985796c57f4321b85fb9a"
-    mount_location: "/cache/model/qwen3"
+    mount_location: "/weights/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "python3 -m sglang.launch_server --model-path /cache/model/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-32B --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /weights/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-32B --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-32B-sglang/config.yaml
+++ b/qwen/qwen-3-32B-sglang/config.yaml
@@ -14,16 +14,14 @@ model_metadata:
 model_name: Qwen 3 32B SGLang
 base_image:
   image: lmsysorg/sglang:v0.4.6.post1-cu124
-model_cache:
-  - repo_id: Qwen/Qwen3-32B-FP8
-    revision: 37f3f67a7a82b002377985796c57f4321b85fb9a
-    use_volume: true
-    volume_folder: "qwen3"
+weights:
+  - source: "hf://Qwen/Qwen3-32B-FP8@37f3f67a7a82b002377985796c57f4321b85fb9a"
+    mount_location: "/app/model_cache/qwen3"
     ignore_patterns:
       - "original/*"
       - "*.pth"
 docker_server:
-  start_command: sh -c "truss-transfer-cli && python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-32B --tp 1 --reasoning-parser qwen3"
+  start_command: sh -c "python3 -m sglang.launch_server --model-path /app/model_cache/qwen3 --host 0.0.0.0 --port 8000 --served-model-name Qwen/Qwen3-32B --tp 1 --reasoning-parser qwen3"
   readiness_endpoint: /health
   liveness_endpoint: /health
   predict_endpoint: /v1/chat/completions

--- a/qwen/qwen-3-next-80B-A3-instruct-sglang/config.yaml
+++ b/qwen/qwen-3-next-80B-A3-instruct-sglang/config.yaml
@@ -32,5 +32,5 @@ runtime:
   predict_concurrency: 128
 weights:
   - source: "hf://Qwen/Qwen3-Next-80B-A3B-Instruct-FP8@c5f5f263bdd5cc134092897864e8905d8fe7b928"
-    mount_location: "/cache/model/qwen"
+    mount_location: "/weights/qwen"
 model_name: Qwen3-Next-80B-A3B-Instruct

--- a/qwen/qwen-3-next-80B-A3-instruct-sglang/config.yaml
+++ b/qwen/qwen-3-next-80B-A3-instruct-sglang/config.yaml
@@ -30,9 +30,7 @@ resources:
   use_gpu: true
 runtime:
   predict_concurrency: 128
-model_cache:
-  - repo_id: Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
-    revision: c5f5f263bdd5cc134092897864e8905d8fe7b928
-    use_volume: true
-    volume_folder: qwen
+weights:
+  - source: "hf://Qwen/Qwen3-Next-80B-A3B-Instruct-FP8@c5f5f263bdd5cc134092897864e8905d8fe7b928"
+    mount_location: "/app/model_cache/qwen"
 model_name: Qwen3-Next-80B-A3B-Instruct

--- a/qwen/qwen-3-next-80B-A3-instruct-sglang/config.yaml
+++ b/qwen/qwen-3-next-80B-A3-instruct-sglang/config.yaml
@@ -32,5 +32,5 @@ runtime:
   predict_concurrency: 128
 weights:
   - source: "hf://Qwen/Qwen3-Next-80B-A3B-Instruct-FP8@c5f5f263bdd5cc134092897864e8905d8fe7b928"
-    mount_location: "/app/model_cache/qwen"
+    mount_location: "/cache/model/qwen"
 model_name: Qwen3-Next-80B-A3B-Instruct

--- a/qwen/qwen-3-next-80B-A3-thinking-sglang/config.yaml
+++ b/qwen/qwen-3-next-80B-A3-thinking-sglang/config.yaml
@@ -32,5 +32,5 @@ runtime:
   predict_concurrency: 128
 weights:
   - source: "hf://Qwen/Qwen3-Next-80B-A3B-Thinking-FP8@1a28d48a94e799860201879be67616b9e21c4bd2"
-    mount_location: "/cache/model/qwen"
+    mount_location: "/weights/qwen"
 model_name: Qwen3-Next-80B-A3B-Thinking

--- a/qwen/qwen-3-next-80B-A3-thinking-sglang/config.yaml
+++ b/qwen/qwen-3-next-80B-A3-thinking-sglang/config.yaml
@@ -30,9 +30,7 @@ resources:
   use_gpu: true
 runtime:
   predict_concurrency: 128
-model_cache:
-  - repo_id: Qwen/Qwen3-Next-80B-A3B-Thinking-FP8
-    revision: 1a28d48a94e799860201879be67616b9e21c4bd2
-    use_volume: true
-    volume_folder: qwen
+weights:
+  - source: "hf://Qwen/Qwen3-Next-80B-A3B-Thinking-FP8@1a28d48a94e799860201879be67616b9e21c4bd2"
+    mount_location: "/app/model_cache/qwen"
 model_name: Qwen3-Next-80B-A3B-Thinking

--- a/qwen/qwen-3-next-80B-A3-thinking-sglang/config.yaml
+++ b/qwen/qwen-3-next-80B-A3-thinking-sglang/config.yaml
@@ -32,5 +32,5 @@ runtime:
   predict_concurrency: 128
 weights:
   - source: "hf://Qwen/Qwen3-Next-80B-A3B-Thinking-FP8@1a28d48a94e799860201879be67616b9e21c4bd2"
-    mount_location: "/app/model_cache/qwen"
+    mount_location: "/cache/model/qwen"
 model_name: Qwen3-Next-80B-A3B-Thinking

--- a/qwen/qwen-3-vl-32b/config.yaml
+++ b/qwen/qwen-3-vl-32b/config.yaml
@@ -23,11 +23,9 @@ requirements:
   - open-clip-torch
   - pillow
 python_version: py312
-model_cache:
-  - repo_id: Qwen/Qwen3-VL-32B-Instruct-FP8
-    revision: main
-    use_volume: true
-    volume_folder: "qwen-3-vl-32b"
+weights:
+  - source: "hf://Qwen/Qwen3-VL-32B-Instruct-FP8@main"
+    mount_location: "/app/model_cache/qwen-3-vl-32b"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/qwen/qwen-3-vl-32b/config.yaml
+++ b/qwen/qwen-3-vl-32b/config.yaml
@@ -25,7 +25,7 @@ requirements:
 python_version: py312
 weights:
   - source: "hf://Qwen/Qwen3-VL-32B-Instruct-FP8@main"
-    mount_location: "/cache/model/qwen-3-vl-32b"
+    mount_location: "/weights/qwen-3-vl-32b"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/qwen/qwen-3-vl-32b/config.yaml
+++ b/qwen/qwen-3-vl-32b/config.yaml
@@ -25,7 +25,7 @@ requirements:
 python_version: py312
 weights:
   - source: "hf://Qwen/Qwen3-VL-32B-Instruct-FP8@main"
-    mount_location: "/app/model_cache/qwen-3-vl-32b"
+    mount_location: "/cache/model/qwen-3-vl-32b"
     ignore_patterns:
       - "original/*"
       - "*.pth"

--- a/qwen/qwen-image/config.yaml
+++ b/qwen/qwen-image/config.yaml
@@ -1,7 +1,7 @@
 external_package_dirs: []
-model_cache:
-  - repo_id: Qwen/Qwen-Image
-    use_volume: false
+weights:
+  - source: "hf://Qwen/Qwen-Image@main"
+    mount_location: "/models/Qwen-Image"
     allow_patterns:
       - "*.json"
       - "*.safetensors"

--- a/qwen/qwen-vl/config.yaml
+++ b/qwen/qwen-vl/config.yaml
@@ -1,14 +1,14 @@
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - '*.bin'
-  - '*.tiktoken'
-  - '*.py'
-  repo_id: Qwen/Qwen-VL
-  use_volume: false
+weights:
+  - source: "hf://Qwen/Qwen-VL@main"
+    mount_location: "/models/Qwen-VL"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "*.bin"
+      - "*.tiktoken"
+      - "*.py"
 model_name: Qwen VL
 python_version: py310
 requirements:

--- a/seed/seed_llm/config.yaml
+++ b/seed/seed_llm/config.yaml
@@ -31,5 +31,5 @@ runtime:
   predict_concurrency: 128
 weights:
   - source: "hf://ByteDance-Seed/Seed-OSS-36B-Instruct@497f1dca95ebdec98e41d517b9f060ee753c902f"
-    mount_location: "/app/model_cache/glm"
+    mount_location: "/cache/model/glm"
 model_name: Seed-OSS-36B-Instruct

--- a/seed/seed_llm/config.yaml
+++ b/seed/seed_llm/config.yaml
@@ -31,5 +31,5 @@ runtime:
   predict_concurrency: 128
 weights:
   - source: "hf://ByteDance-Seed/Seed-OSS-36B-Instruct@497f1dca95ebdec98e41d517b9f060ee753c902f"
-    mount_location: "/cache/model/glm"
+    mount_location: "/weights/glm"
 model_name: Seed-OSS-36B-Instruct

--- a/seed/seed_llm/config.yaml
+++ b/seed/seed_llm/config.yaml
@@ -29,9 +29,7 @@ resources:
   use_gpu: true
 runtime:
   predict_concurrency: 128
-model_cache:
-  - repo_id: ByteDance-Seed/Seed-OSS-36B-Instruct
-    revision: 497f1dca95ebdec98e41d517b9f060ee753c902f
-    use_volume: true
-    volume_folder: glm
+weights:
+  - source: "hf://ByteDance-Seed/Seed-OSS-36B-Instruct@497f1dca95ebdec98e41d517b9f060ee753c902f"
+    mount_location: "/app/model_cache/glm"
 model_name: Seed-OSS-36B-Instruct

--- a/stable-diffusion/playground-v2-trt/config.yaml
+++ b/stable-diffusion/playground-v2-trt/config.yaml
@@ -5,18 +5,20 @@ description: Generate original images from text prompts.
 environment_variables:
   HF_HUB_ENABLE_HF_TRANSFER: 1
 external_package_dirs: []
-model_cache:
-- repo_id: baseten/playground-v2-trt-8.6.1.post1-engine-A100
-  use_volume: false
-- allow_patterns:
-  - config.json
-  - diffusion_pytorch_model.safetensors
-  repo_id: madebyollin/sdxl-vae-fp16-fix
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - playground-v2.safetensors
-  repo_id: playgroundai/playground-v2-1024px-aesthetic
+weights:
+  - source: "hf://baseten/playground-v2-trt-8.6.1.post1-engine-A100@main"
+    mount_location: "/models/playground-v2-trt-8.6.1.post1-engine-A100"
+  - source: "hf://madebyollin/sdxl-vae-fp16-fix@main"
+    mount_location: "/models/sdxl-vae-fp16-fix"
+    allow_patterns:
+      - "config.json"
+      - "diffusion_pytorch_model.safetensors"
+  - source: "hf://playgroundai/playground-v2-1024px-aesthetic@main"
+    mount_location: "/models/playground-v2-1024px-aesthetic"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "playground-v2.safetensors"
 model_metadata:
   example_model_input:
     prompt: Astronaut in a jungle, cold color palette, muted colors, detailed, 8k

--- a/stable-diffusion/sd-turbo/config.yaml
+++ b/stable-diffusion/sd-turbo/config.yaml
@@ -1,12 +1,12 @@
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - '*.txt'
-  repo_id: stabilityai/sdxl-turbo
-  use_volume: false
+weights:
+  - source: "hf://stabilityai/sdxl-turbo@main"
+    mount_location: "/models/sdxl-turbo"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "*.txt"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/stability.png
   cover_image_url: https://cdn.baseten.co/production/static/sd.png

--- a/stable-diffusion/sdxl-turbo/config.yaml
+++ b/stable-diffusion/sdxl-turbo/config.yaml
@@ -1,12 +1,12 @@
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - '*.txt'
-  repo_id: stabilityai/sdxl-turbo
-  use_volume: false
+weights:
+  - source: "hf://stabilityai/sdxl-turbo@main"
+    mount_location: "/models/sdxl-turbo"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "*.txt"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/stability.png
   cover_image_url: https://cdn.baseten.co/production/static/sd.png

--- a/stable-diffusion/stable-diffusion-3-medium/config.yaml
+++ b/stable-diffusion/stable-diffusion-3-medium/config.yaml
@@ -2,9 +2,9 @@ environment_variables:
   HF_HUB_OFFLINE: 1
 external_package_dirs: []
 model_metadata: {}
-model_cache:
-  - repo_id: stabilityai/stable-diffusion-3-medium-diffusers
-    use_volume: false
+weights:
+  - source: "hf://stabilityai/stable-diffusion-3-medium-diffusers@main"
+    mount_location: "/models/stable-diffusion-3-medium-diffusers"
 model_name: Stable Diffusion 3 Medium
 python_version: py310
 requirements:

--- a/stable-diffusion/stable-diffusion-xl-1.0-trt-h100/config.yaml
+++ b/stable-diffusion/stable-diffusion-xl-1.0-trt-h100/config.yaml
@@ -5,23 +5,26 @@ description: Generate original images from text prompts.
 environment_variables:
   HF_HUB_ENABLE_HF_TRANSFER: 1
 external_package_dirs: []
-model_cache:
-- repo_id: baseten/sdxl-1.0-trt-8.6.1.post1-engine-H100
-  use_volume: false
-- allow_patterns:
-  - config.json
-  - diffusion_pytorch_model.safetensors
-  repo_id: madebyollin/sdxl-vae-fp16-fix
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - sd_xl_base_1.0.safetensors
-  repo_id: stabilityai/stable-diffusion-xl-base-1.0
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - sd_xl_refiner_1.0.safetensors
-  repo_id: stabilityai/stable-diffusion-xl-refiner-1.0
+weights:
+  - source: "hf://baseten/sdxl-1.0-trt-8.6.1.post1-engine-H100@main"
+    mount_location: "/models/sdxl-1.0-trt-8.6.1.post1-engine-H100"
+  - source: "hf://madebyollin/sdxl-vae-fp16-fix@main"
+    mount_location: "/models/sdxl-vae-fp16-fix"
+    allow_patterns:
+      - "config.json"
+      - "diffusion_pytorch_model.safetensors"
+  - source: "hf://stabilityai/stable-diffusion-xl-base-1.0@main"
+    mount_location: "/models/stable-diffusion-xl-base-1.0"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "sd_xl_base_1.0.safetensors"
+  - source: "hf://stabilityai/stable-diffusion-xl-refiner-1.0@main"
+    mount_location: "/models/stable-diffusion-xl-refiner-1.0"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "sd_xl_refiner_1.0.safetensors"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/stability.png
   cover_image_url: https://cdn.baseten.co/production/static/sd.png

--- a/stable-diffusion/stable-diffusion-xl-1.0-trt/config.yaml
+++ b/stable-diffusion/stable-diffusion-xl-1.0-trt/config.yaml
@@ -5,23 +5,26 @@ description: Generate original images from text prompts.
 environment_variables:
   HF_HUB_ENABLE_HF_TRANSFER: 1
 external_package_dirs: []
-model_cache:
-- repo_id: baseten/sdxl-1.0-trt-8.6.1.post1-engine
-  use_volume: false
-- allow_patterns:
-  - config.json
-  - diffusion_pytorch_model.safetensors
-  repo_id: madebyollin/sdxl-vae-fp16-fix
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - sd_xl_base_1.0.safetensors
-  repo_id: stabilityai/stable-diffusion-xl-base-1.0
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - sd_xl_refiner_1.0.safetensors
-  repo_id: stabilityai/stable-diffusion-xl-refiner-1.0
+weights:
+  - source: "hf://baseten/sdxl-1.0-trt-8.6.1.post1-engine@main"
+    mount_location: "/models/sdxl-1.0-trt-8.6.1.post1-engine"
+  - source: "hf://madebyollin/sdxl-vae-fp16-fix@main"
+    mount_location: "/models/sdxl-vae-fp16-fix"
+    allow_patterns:
+      - "config.json"
+      - "diffusion_pytorch_model.safetensors"
+  - source: "hf://stabilityai/stable-diffusion-xl-base-1.0@main"
+    mount_location: "/models/stable-diffusion-xl-base-1.0"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "sd_xl_base_1.0.safetensors"
+  - source: "hf://stabilityai/stable-diffusion-xl-refiner-1.0@main"
+    mount_location: "/models/stable-diffusion-xl-refiner-1.0"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "sd_xl_refiner_1.0.safetensors"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/stability.png
   cover_image_url: https://cdn.baseten.co/production/static/sd.png

--- a/stable-diffusion/stable-diffusion-xl-1.0/config.yaml
+++ b/stable-diffusion/stable-diffusion-xl-1.0/config.yaml
@@ -1,24 +1,24 @@
 description: Generate original images from text prompts.
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- allow_patterns:
-  - config.json
-  - diffusion_pytorch_model.safetensors
-  repo_id: madebyollin/sdxl-vae-fp16-fix
-  use_volume: false
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - sd_xl_base_1.0.safetensors
-  repo_id: stabilityai/stable-diffusion-xl-base-1.0
-  use_volume: false
-- allow_patterns:
-  - '*.json'
-  - '*.fp16.safetensors'
-  - sd_xl_refiner_1.0.safetensors
-  repo_id: stabilityai/stable-diffusion-xl-refiner-1.0
-  use_volume: false
+weights:
+  - source: "hf://madebyollin/sdxl-vae-fp16-fix@main"
+    mount_location: "/models/sdxl-vae-fp16-fix"
+    allow_patterns:
+      - "config.json"
+      - "diffusion_pytorch_model.safetensors"
+  - source: "hf://stabilityai/stable-diffusion-xl-base-1.0@main"
+    mount_location: "/models/stable-diffusion-xl-base-1.0"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "sd_xl_base_1.0.safetensors"
+  - source: "hf://stabilityai/stable-diffusion-xl-refiner-1.0@main"
+    mount_location: "/models/stable-diffusion-xl-refiner-1.0"
+    allow_patterns:
+      - "*.json"
+      - "*.fp16.safetensors"
+      - "sd_xl_refiner_1.0.safetensors"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/stability.png
   cover_image_url: https://cdn.baseten.co/production/static/sd.png

--- a/whisper/faster-whisper-small/config.yaml
+++ b/whisper/faster-whisper-small/config.yaml
@@ -1,7 +1,7 @@
 description: A small speech-to-text model for multi-lingual audio transcription.
-model_cache:
-- repo_id: Systran/faster-whisper-small
-  use_volume: false
+weights:
+  - source: "hf://Systran/faster-whisper-small@main"
+    mount_location: "/models/faster-whisper-small"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/openai.png
   cover_image_url: https://cdn.baseten.co/production/static/whisper.png

--- a/whisper/faster-whisper-v2/config.yaml
+++ b/whisper/faster-whisper-v2/config.yaml
@@ -1,9 +1,9 @@
 description: Faster Whisper v2
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- repo_id: Systran/faster-whisper-large-v2
-  use_volume: false
+weights:
+  - source: "hf://Systran/faster-whisper-large-v2@main"
+    mount_location: "/models/faster-whisper-large-v2"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/openai.png
   cover_image_url: https://cdn.baseten.co/production/static/whisper.png

--- a/whisper/faster-whisper-v3/config.yaml
+++ b/whisper/faster-whisper-v3/config.yaml
@@ -1,9 +1,9 @@
 description: Faster Whisper v3
 environment_variables: {}
 external_package_dirs: []
-model_cache:
-- repo_id: Systran/faster-whisper-large-v3
-  use_volume: false
+weights:
+  - source: "hf://Systran/faster-whisper-large-v3@main"
+    mount_location: "/models/faster-whisper-large-v3"
 model_metadata:
   avatar_url: https://cdn.baseten.co/production/static/openai.png
   cover_image_url: https://cdn.baseten.co/production/static/whisper.png

--- a/whisper/whisper-torchserve/config.yaml
+++ b/whisper/whisper-torchserve/config.yaml
@@ -13,9 +13,9 @@ requirements:
 resources:
   accelerator: T4
   use_gpu: true
-model_cache:
-  - repo_id: htrivedi99/whisper-torchserve
-    use_volume: false
+weights:
+  - source: "hf://htrivedi99/whisper-torchserve@main"
+    mount_location: "/models/whisper-torchserve"
 secrets: {}
 system_packages:
   - ffmpeg


### PR DESCRIPTION
## Summary

Migrates example `config.yaml` files from the legacy `model_cache` field to the new `weights` field (BDN). Each conversion:
