### PR TITLE
fix: guard HF_TOKEN env assignment against None when secret is not configured

### DIFF
--- a/mistral/mistral-7b-instruct-vllm/model/model.py
+++ b/mistral/mistral-7b-instruct-vllm/model/model.py
@@ -13,7 +13,8 @@ class Model:
         self.engine_args = kwargs["config"]["model_metadata"]["engine_args"]
         self.prompt_format = kwargs["config"]["model_metadata"]["prompt_format"]
         self.hf_secret_token = kwargs["secrets"].get("hf_access_token", None)
-        os.environ["HF_TOKEN"] = self.hf_secret_token
+        if self.hf_secret_token:
+            os.environ["HF_TOKEN"] = self.hf_secret_token
 
     def load(self) -> None:
         self.llm_engine = AsyncLLMEngine.from_engine_args(

--- a/phi/phi-3.5-mini/model/model.py
+++ b/phi/phi-3.5-mini/model/model.py
@@ -32,7 +32,8 @@ class Model:
             "openai_compatible", False
         )
         self.vllm_base_url = None
-        os.environ["HF_TOKEN"] = self.hf_secret_token
+        if self.hf_secret_token:
+            os.environ["HF_TOKEN"] = self.hf_secret_token
 
     def load(self):
         self._model_metadata = self._config["model_metadata"]

--- a/vllm/model/model.py
+++ b/vllm/model/model.py
@@ -32,7 +32,8 @@ class Model:
             "openai_compatible", False
         )
         self.vllm_base_url = None
-        os.environ["HF_TOKEN"] = self.hf_secret_token
+        if self.hf_secret_token:
+            os.environ["HF_TOKEN"] = self.hf_secret_token
 
     def load(self):
         self._model_metadata = self._config["model_metadata"]


### PR DESCRIPTION
This crashes the model at construction time — before `load()` is ever called —
with a confusing error unrelated to the actual missing configuration.

## How

Wrap each assignment in a `if self.hf_secret_token:` guard, matching the pattern
already used correctly in `flux.1-dev-trt-b200/model/model.py`,
`ngram-speculator/truss/model/model.py`, and `midnight/model/model.py`.

## Testing

The fix is a one-line guard per file. No functional change for deployments that
do supply `hf_access_token`; deployments against public models without the secret
configured will now load successfully instead of crashing.