### PR TITLE
docs: fix Mixtral README typo

### DIFF
--- a/mistral/mixtral-8x7b-instruct-trt-llm-weights-only-quant/README.md
+++ b/mistral/mixtral-8x7b-instruct-trt-llm-weights-only-quant/README.md
@@ -45,7 +45,7 @@ This model is designed for our ChatCompletions endpoint:
 We expect requests will the following information:
 
 - ```messages``` (str): The prompt you'd like to complete
-- ```max_tokens``` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just recieve a truncated version of the prompt.
+- ```max_tokens``` (int, default: 50): The max token count. This includes the number of tokens in your prompt so if this value is less than your prompt, you'll just receive a truncated version of the prompt.
 - ```beam_width``` (int, default:50): The number of beams to compute. This must be 1 for this version of TRT-LLM. Inflight-batching does not support beams > 1.
 - ```bad_words_list``` (list, default:[]): A list of words to not include in generated output.
 - ```stop_words_list``` (list, default:[]): A list of words to stop generation upon encountering.


### PR DESCRIPTION
## Problem
The Mixtral TRT-LLM weights-only quantization README has a small spelling typo in the `max_tokens` parameter description: `recieve`.

## Solution
Corrected `recieve` to `receive`.

## Validation
- Confirmed the misspelling no longer appears in the edited README.
- Ran `git diff --check`.

Confidence: 85/100 (docs/typo)