### PR TITLE
Add inference SSH tune-vllm-args example

### DIFF
--- a/inference-ssh/README.md
+++ b/inference-ssh/README.md
@@ -1,0 +1,7 @@
+# Inference SSH examples
+
+These examples use Baseten's [SSH access](https://docs.baseten.co/inference/ssh) to
+connect to a running model deployment and work inside the container.
+
+- [tune-vllm-args](tune-vllm-args) — SSH into a running vLLM server, edit its launch
+  args and chat template, and restart the engine in place.

--- a/inference-ssh/tune-vllm-args/README.md
+++ b/inference-ssh/tune-vllm-args/README.md
@@ -17,46 +17,18 @@ on a single L4 GPU.
 
 ## 1. Set up SSH
 
-Set up SSH once per machine, using the
-[Truss CLI](https://docs.baseten.co/reference/cli/truss/overview) or the
-[Baseten CLI](https://docs.baseten.co/reference/cli/baseten/overview). Install
-whichever you prefer by following its docs, then run its setup below. For background
+Set up SSH once per machine with the
+[Baseten CLI](https://docs.baseten.co/reference/cli/baseten/overview). For background
 on SSH access, see the [SSH docs](https://docs.baseten.co/inference/ssh).
-
-**Using the Truss CLI**
-
-```sh
-truss login
-truss ssh setup
-```
-
-When `truss login` prompts for an authentication method, choose the API key option.
-SSH signing needs the API key stored locally, so browser login alone will not work
-for `truss ssh`.
-
-**Using the Baseten CLI**
 
 ```sh
 baseten auth login
 baseten ssh setup
 ```
 
-> **Note:** Baseten CLI SSH is not released yet, so the Baseten CLI must be
-> [built from source](https://github.com/basetenlabs/baseten-cli#building) and put on
-> PATH to use it.
-
 ## 2. Deploy
 
-Push with the Truss CLI or the Baseten CLI. Both accept `--wait` to block until the
-deployment is `ACTIVE`.
-
-**Using the Truss CLI**
-
-```sh
-truss push inference-ssh/tune-vllm-args --wait
-```
-
-**Using the Baseten CLI**
+Push with the Baseten CLI. Pass `--wait` to block until the deployment is `ACTIVE`.
 
 ```sh
 baseten model push --dir inference-ssh/tune-vllm-args --wait
@@ -85,7 +57,7 @@ export MY_MODEL_ID=<model_id>
 
 **Using curl**
 
-Set your Baseten API key too.
+Using curl needs an API key:
 
 ```sh
 export MY_API_KEY=<your-api-key>

--- a/inference-ssh/tune-vllm-args/README.md
+++ b/inference-ssh/tune-vllm-args/README.md
@@ -1,0 +1,182 @@
+# Tune vLLM args over SSH
+
+This example demonstrates an in-container development loop over SSH. It deploys a small
+vLLM server with SSH access enabled, then shows how to SSH into a running replica, edit
+files in place, and restart the app to pick up the changes without redeploying or
+recreating the container.
+
+The server is launched by [`entr`](https://eradman.com/entrproject/), which watches
+the files in `/app/data` and relaunches vLLM whenever one of them changes. Every
+vLLM flag lives in [`data/vllm_args.txt`](data/vllm_args.txt), and the assistant
+persona lives in [`data/chat_template.jinja`](data/chat_template.jinja). See
+[`config.yaml`](config.yaml) for how it is wired together. SSH into the replica, edit
+either file, and `entr` restarts the vLLM engine in place.
+
+It serves [Qwen/Qwen2.5-0.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct)
+on a single L4 GPU.
+
+## 1. Set up SSH
+
+Set up SSH once per machine, using the
+[Truss CLI](https://docs.baseten.co/reference/cli/truss/overview) or the
+[Baseten CLI](https://docs.baseten.co/reference/cli/baseten/overview). Install
+whichever you prefer by following its docs, then run its setup below. For background
+on SSH access, see the [SSH docs](https://docs.baseten.co/inference/ssh).
+
+**Using the Truss CLI**
+
+```sh
+truss login
+truss ssh setup
+```
+
+When `truss login` prompts for an authentication method, choose the API key option.
+SSH signing needs the API key stored locally, so browser login alone will not work
+for `truss ssh`.
+
+**Using the Baseten CLI**
+
+```sh
+baseten auth login
+baseten ssh setup
+```
+
+> **Note:** Baseten CLI SSH is not released yet, so the Baseten CLI must be
+> [built from source](https://github.com/basetenlabs/baseten-cli#building) and put on
+> PATH to use it.
+
+## 2. Deploy
+
+Push with the Truss CLI or the Baseten CLI. Both accept `--wait` to block until the
+deployment is `ACTIVE`.
+
+**Using the Truss CLI**
+
+```sh
+truss push inference-ssh/tune-vllm-args --wait
+```
+
+**Using the Baseten CLI**
+
+```sh
+baseten model push --dir inference-ssh/tune-vllm-args --wait
+```
+
+Note the **model ID** and **deployment ID** from the output. You will use them to
+call the model and to SSH in.
+
+The first deploy pulls the vLLM base image and does a full vLLM startup, which takes
+several minutes. Restarting vLLM later over SSH is much faster.
+
+## 3. Keep a replica running
+
+In the Baseten UI, open the deployment and set both **min and max replicas to 1**.
+This keeps exactly one replica up while you tweak. An active SSH session does not by
+itself prevent scale-down, so without a pinned replica your session would be
+terminated when the deployment scales to zero.
+
+## 4. Call the model
+
+Set the model ID from the push output as an environment variable.
+
+```sh
+export MY_MODEL_ID=<model_id>
+```
+
+**Using curl**
+
+Set your Baseten API key too.
+
+```sh
+export MY_API_KEY=<your-api-key>
+```
+
+Then run the request.
+
+```sh
+curl -s https://model-$MY_MODEL_ID.api.baseten.co/environments/production/sync/v1/chat/completions \
+  -H "Authorization: Bearer $MY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-0.5B-Instruct",
+    "messages": [{"role": "user", "content": "What is the meaning of life?"}]
+  }' | jq -r '.choices[0].message.content'
+```
+
+**Using the Baseten CLI**
+
+```sh
+baseten model predict --model-id $MY_MODEL_ID --data '{
+  "model": "Qwen/Qwen2.5-0.5B-Instruct",
+  "messages": [{"role": "user", "content": "What is the meaning of life?"}]
+}' --jq '.choices[0].message.content'
+```
+
+The example ships with a pirate persona in
+[`data/chat_template.jinja`](data/chat_template.jinja), so the reply comes back in
+pirate voice:
+
+> Oh matey! The answer to that's an arrrrly question! Life ain't no game for us, matey!
+> It's a quest, matey! To find the meaning, matey, we gotta dive deep into the sea and
+> seek the depths of the ocean!
+
+## 5. Tune over SSH and call again
+
+**Connect to the replica**
+
+Set the model ID and deployment ID from the push output as environment variables.
+
+```sh
+export MY_MODEL_ID=<model_id>
+export MY_DEPLOYMENT_ID=<deployment_id>
+```
+
+Then connect over SSH.
+
+```sh
+ssh model-$MY_MODEL_ID-$MY_DEPLOYMENT_ID.ssh.baseten.co
+```
+
+You can also connect from your editor. With the
+[VS Code Remote - SSH extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)
+or Cursor's SSH remote, connect to the same
+`model-<model_id>-<deployment_id>.ssh.baseten.co` host and edit the files directly.
+
+**Change the persona**
+
+Edit the persona line near the top of
+[`data/chat_template.jinja`](data/chat_template.jinja) and save.
+
+```sh
+vi /app/data/chat_template.jinja
+```
+
+`nano` is also installed if you prefer it.
+
+For example, swap the pirate for Shakespeare:
+
+```diff
+-{%- set persona = "You are a swashbuckling pirate. Answer every question in boisterous pirate slang, packed with 'arrr', 'matey', and nautical metaphors." -%}
++{%- set persona = "You are William Shakespeare. Answer every question in florid Elizabethan English, in iambic pentameter where the meter allows." -%}
+```
+
+`entr` picks up the change and restarts vLLM in place. Watch the deployment logs in the
+Baseten dashboard to see it restart, and wait for the restart to finish. Once it does,
+the assistant adopts the new persona.
+
+The reload reinitializes the engine and reloads the Python stack, so it takes a bit, but
+it is much faster than the first deploy because the image, weights, and JIT caches are
+already warm.
+
+> **Note:** The same works for any vLLM flag. Edit
+> [`data/vllm_args.txt`](data/vllm_args.txt) to change `--max-model-len` or add
+> another argument, and saving restarts the engine the same way.
+
+**Call the model again**
+
+Re-run the call from step 4 and compare the response. With the Shakespeare persona, the
+same prompt comes back as:
+
+> The meaning of life, my lord, is to know and love; it's a quest for wisdom, for truth,
+> and for joy; it's not just about surviving but to live fully, to be happy, and to
+> serve our Maker with all we have.

--- a/inference-ssh/tune-vllm-args/config.yaml
+++ b/inference-ssh/tune-vllm-args/config.yaml
@@ -1,0 +1,50 @@
+model_name: tune-vllm-args
+
+# Serve an OpenAI-compatible API straight from the official vLLM image.
+base_image:
+  image: vllm/vllm-openai:v0.12.0
+
+# entr is not in the vLLM image, so install it at build time. We use it to
+# relaunch vLLM whenever the tunable args file changes. vim and nano give us an
+# editor for tweaking those files over SSH.
+build_commands:
+  - "apt-get update && apt-get install -y --no-install-recommends entr vim nano"
+
+docker_server:
+  # entr watches the editable files in /app/data and restarts vLLM when any of
+  # them changes. entr itself stays running as the server process, so editing a
+  # file over SSH restarts the engine without recreating the container. Every
+  # vLLM flag lives in vllm_args.txt, including the chat template that sets the
+  # assistant persona.
+  start_command: >-
+    sh -c "find /app/data -maxdepth 1 -type f |
+    entr -nr sh -c 'vllm serve Qwen/Qwen2.5-0.5B-Instruct $(cat /app/data/vllm_args.txt)'"
+  readiness_endpoint: /health
+  liveness_endpoint: /health
+  predict_endpoint: /v1/chat/completions
+  server_port: 8000
+
+# Smallest, cheapest GPU that runs the stock vLLM image cleanly.
+resources:
+  instance_type: "L4:4x16"
+
+runtime:
+  # Turn on SSH access to the running container.
+  remote_ssh:
+    enabled: true
+  # Give a restart plenty of time before the container is considered unhealthy,
+  # so tweaking args and relaunching vLLM does not trip a pod restart.
+  health_checks:
+    restart_threshold_seconds: 300
+    stop_traffic_threshold_seconds: 120
+
+model_metadata:
+  example_model_input:
+    model: Qwen/Qwen2.5-0.5B-Instruct
+    messages:
+      - role: user
+        content: "What is the meaning of life?"
+    max_tokens: 512
+    temperature: 0.6
+  tags:
+    - openai-compatible

--- a/inference-ssh/tune-vllm-args/data/chat_template.jinja
+++ b/inference-ssh/tune-vllm-args/data/chat_template.jinja
@@ -1,0 +1,11 @@
+{#- Edit the persona below and save the file to change how the assistant talks. -#}
+{%- set persona = "You are a swashbuckling pirate. Answer every question in boisterous pirate slang, packed with 'arrr', 'matey', and nautical metaphors." -%}
+{{- '<|im_start|>system\n' + persona + '<|im_end|>\n' -}}
+{%- for message in messages -%}
+{%- if message.role != 'system' -%}
+{{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>\n' -}}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{- '<|im_start|>assistant\n' -}}
+{%- endif -%}

--- a/inference-ssh/tune-vllm-args/data/vllm_args.txt
+++ b/inference-ssh/tune-vllm-args/data/vllm_args.txt
@@ -1,0 +1,5 @@
+--host 0.0.0.0
+--port 8000
+--chat-template /app/data/chat_template.jinja
+--max-model-len 8192
+--enforce-eager


### PR DESCRIPTION
## What changed

Adds a new `inference-ssh/` example category demonstrating an in-container
development loop over SSH, plus its first example, `tune-vllm-args`.

- Deploys a small vLLM server (Qwen2.5-0.5B on an L4) as a custom `docker_server` with `runtime.remote_ssh.enabled`.
- The server runs under `entr`, which watches `data/` and restarts vLLM in place whenever a file changes, so edits over SSH take effect without redeploying.
- Walkthrough README covers SSH setup with Baseten CLI, deploy, pinning a replica, calling the model, and the SSH edit/restart loop, using a chat-template persona swap (pirate to Shakespeare) as the visible example.
- Adds an `inference-ssh/` index README linking the SSH docs.

Note, an earlier version of this worked with `truss` CLI in addition to `baseten` CLI, but now the `truss` one has been removed