### PR TITLE
Pin huggingface_hub==0.25.2 in sd-turbo example

### DIFF
--- a/stable-diffusion/sd-turbo/config.yaml
+++ b/stable-diffusion/sd-turbo/config.yaml
@@ -22,6 +22,7 @@ requirements:
 - transformers==4.35.2
 - diffusers==0.23.1
 - accelerate==0.24.1
+- huggingface_hub==0.25.2
 resources:
   accelerator: T4
   use_gpu: true


### PR DESCRIPTION
## Problem

The `stable-diffusion/sd-turbo` example fails to deploy. The model server crash-loops during `model.load()` and the deployment never becomes healthy. The runtime logs only show:

```
Loading truss model from file.
Exception while loading model
Trying shut down after failed model load.
Replica terminated due to health check failures. The replica took too long to become ready or failed health checks. Exit code: 0, reason: HealthCheckFailure, restart count: 3
```

## Root cause

`huggingface_hub` is not pinned in `config.yaml`, while `diffusers` is pinned to 0.23.1 (Nov 2023). Fresh builds now resolve `huggingface_hub` 0.36.x, which removed `cached_download` and `HfFolder` — symbols that diffusers 0.23.1 imports at module load. Reproduced locally with `diffusers==0.23.1` + `huggingface_hub==0.36.2`:

```
File "diffusers/utils/dynamic_modules_utils.py", line 28, in <module>
  from huggingface_hub import HfFolder, cached_download, hf_hub_download, model_info
ImportError: cannot import name 'cached_download' from 'huggingface_hub'. Did you mean: 'hf_hub_download'?
```

(The `ImportError` fires ~3s after "Loading truss model from file", which is why the platform logs show no traceback — the model module never finishes importing.)

## Fix

Pin `huggingface_hub==0.25.2` — the last release that still provides `cached_download`/`HfFolder`, and compatible with the example's pinned `transformers==4.35.2` (requires `<1.0`) and `diffusers==0.23.1` (requires `>=0.13.2`).

## Verification

Deployed to Baseten with this pin: build passes, `model.load()` completes in ~37s, and a test request (`{"prompt": "A tree in a field under the night sky", "num_steps": 1}`) returns a valid 512×512 image in under 2 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)