### PR TITLE
fix(whisper-streaming): ASRBase.load_model stub omits model_dir that __init__ passes

### DIFF
--- a/whisper/whisper-streaming/packages/whisper_streaming/whisper_online.py
+++ b/whisper/whisper-streaming/packages/whisper_streaming/whisper_online.py
@@ -41,7 +41,7 @@ class ASRBase:
 
         self.model = self.load_model(modelsize, cache_dir, model_dir)
 
-    def load_model(self, modelsize, cache_dir):
+    def load_model(self, modelsize=None, cache_dir=None, model_dir=None):
         raise NotImplementedError("must be implemented in the child class")
 
     def transcribe(self, audio, init_prompt=""):


### PR DESCRIPTION
### Description

In `whisper/whisper-streaming/packages/whisper_streaming/whisper_online.py`, `ASRBase.__init__` passes three arguments to `load_model`:

```python
# line 42
self.model = self.load_model(modelsize, cache_dir, model_dir)

# line 44 — the stub a new backend is meant to implement
def load_model(self, modelsize, cache_dir):
    raise NotImplementedError("must be implemented in the child class")
```

The stub only declares two. Both concrete backends in the file already take the third:

| line | definition |
|---|---|
| 44 | `ASRBase.load_model(self, modelsize, cache_dir)` ← the odd one out |
| 61 | `WhisperTimestampedASR.load_model(self, modelsize=None, cache_dir=None, model_dir=None)` |
| 107 | `FasterWhisperASR.load_model(self, modelsize=None, cache_dir=None, model_dir=None)` |

So the stub documents a contract the base class itself violates. A backend written against it — the stub is the only signature a subclass author sees — breaks in `ASRBase.__init__`:

```
TypeError: load_model() takes 3 positional arguments but 4 were given
```

Verified by rebuilding each `load_model` signature from the repo file with `ast` and replaying the `__init__` call through `inspect.Signature.bind`:

```
ASRBase                load_model(self, modelsize, cache_dir)                           -> TypeError: too many positional arguments
WhisperTimestampedASR  load_model(self, modelsize=None, cache_dir=None, model_dir=None) -> OK
FasterWhisperASR       load_model(self, modelsize=None, cache_dir=None, model_dir=None) -> OK
```

### Changes

One line: give the `ASRBase.load_model` stub the same signature as its two overrides. Nothing else in the file changes, and no existing backend is affected.

`ruff format --check` (v0.11.6, the pinned pre-commit version) reports the file already formatted, and `ruff check` yields identical findings before and after (two pre-existing `E741`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
